### PR TITLE
Correct imports when imported in certain setups.

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,5 +1,4 @@
-import { Link, LinkProps, Typography, useTheme } from "@mui/material";
-import Grid from "@mui/material/Grid2";
+import { Grid2 as Grid, Link, LinkProps, Typography, useTheme } from "@mui/material";
 
 import React from "react";
 import {

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,4 +1,10 @@
-import { Grid2 as Grid, Link, LinkProps, Typography, useTheme } from "@mui/material";
+import {
+  Grid2 as Grid,
+  Link,
+  LinkProps,
+  Typography,
+  useTheme,
+} from "@mui/material";
 
 import React from "react";
 import {

--- a/src/components/User.tsx
+++ b/src/components/User.tsx
@@ -4,13 +4,13 @@ import {
   Button,
   Box,
   Link,
+  Menu,
+  MenuItem,
   Stack,
   Typography,
   useTheme,
 } from "@mui/material";
 
-import Menu from "@mui/material/Menu";
-import MenuItem from "@mui/material/MenuItem";
 import { ReactNode, useState } from "react";
 
 import { MdLogin } from "react-icons/md";

--- a/src/themes/DiamondTheme.ts
+++ b/src/themes/DiamondTheme.ts
@@ -1,4 +1,4 @@
-import { createTheme, Theme } from "@mui/material/styles";
+import { createTheme, Theme } from "@mui/material";
 
 import { BaseThemeOptions } from "./BaseTheme";
 

--- a/src/themes/GenericTheme.ts
+++ b/src/themes/GenericTheme.ts
@@ -1,4 +1,4 @@
-import { createTheme, Theme } from "@mui/material/styles";
+import { createTheme, Theme } from "@mui/material";
 
 import { BaseThemeOptions } from "./BaseTheme";
 

--- a/src/themes/ThemeProvider.test.tsx
+++ b/src/themes/ThemeProvider.test.tsx
@@ -1,7 +1,7 @@
 import "@testing-library/jest-dom";
 import { render } from "@testing-library/react";
 
-import { createTheme, Theme } from "@mui/material/styles";
+import { createTheme, Theme } from "@mui/material";
 
 import { ThemeProvider } from "./ThemeProvider";
 import { BaseThemeOptions } from "./BaseTheme";

--- a/src/themes/ThemeProvider.tsx
+++ b/src/themes/ThemeProvider.tsx
@@ -1,4 +1,4 @@
-import { ThemeProvider as Mui_ThemeProvider } from "@mui/material/styles";
+import { ThemeProvider as Mui_ThemeProvider } from "@mui/material";
 import { CssBaseline } from "@mui/material";
 import { GenericTheme } from "./GenericTheme";
 import { ThemeProviderProps as Mui_ThemeProviderProps } from "@mui/material/styles/ThemeProvider";


### PR DESCRIPTION
I'm seeing several import errors when adding the component via npmjs in an existing project.

Errors are similar to:

> ERROR in ./node_modules/@diamondlightsource/sci-react-ui/dist/index.esm.js 6:0-36
> Module not found: Error: Can't resolve '@mui/material/Grid2' in '.../frontend/node_modules/@diamondlightsource/sci-react-ui/dist'
> Did you mean 'index.js'?
> BREAKING CHANGE: The request '@mui/material/Grid2' failed to resolve only because it was resolved as fully specified (probably because the origin is strict EcmaScript Module, e. g. a module with javascript mimetype, a '*.mjs' file, or a '*.js' file where the package.json contains '"type": "module"').
> The extension in the request is mandatory for it to be fully specified.
> Add the extension to the request.

These changes fix this error, but  wonder if this isn't a build problem...?!