### PR TITLE
Ensure compatibility with ESM and CommonJS

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,14 +1,15 @@
 node_modules/
-storybook-static/
-.storybook/
 temp/
 coverage/
 
+storybook-static/
+.storybook/
 src/storybook/
 
 .idea/
 .vscode/
 
+.github/
 .gitignore
 
 rollup.config.mjs

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@diamondlightsource/sci-react-ui",
-  "version": "0.0.1",
-  "type": "module",
+  "version": "0.0.2",
   "description": "A theme and component library to make websites at scientific institutions simple to create.",
   "author": "Diamond Light Source",
   "license": "ISC",
@@ -9,6 +8,9 @@
     "type": "git",
     "url": "https://github.com/DiamondLightSource/sci-react-ui.git"
   },
+  "main": "dist/index.cjs.js",
+  "module": "dist/index.esm.js",
+  "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc -b && rollup --config rollup.config.mjs",
     "lint": "eslint .",
@@ -21,9 +23,6 @@
     "storybook:build": "storybook build -o storybook-static",
     "storybook:publish": "gh-pages -b storybook/publish -d storybook-static"
   },
-  "main": "dist/index.cjs.js",
-  "module": "dist/index.esm.js",
-  "types": "dist/index.d.ts",
   "dependencies": {
     "@eslint/eslintrc": "^3.2.0",
     "@mui/icons-material": "^6.1.7",


### PR DESCRIPTION
Removed type:module as superseeded by main and module fields.

Also added .github to npm publish exclude.