### PR TITLE
Add VisitInput return key submit options

### DIFF
--- a/src/components/VisitInput.stories.tsx
+++ b/src/components/VisitInput.stories.tsx
@@ -1,5 +1,5 @@
 import { Meta, StoryObj } from "@storybook/react";
-
+import { Visit } from "../utils/diamond";
 import { VisitInput } from "./VisitInput";
 
 const meta: Meta<typeof VisitInput> = {
@@ -11,6 +11,10 @@ const meta: Meta<typeof VisitInput> = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
+const handleSubmit = (visit: Visit, parameters?: object) => {
+  alert(JSON.stringify({ visit, parameters }));
+};
+
 export const Input: Story = {};
 
 export const InitialVisit: Story = {
@@ -19,13 +23,29 @@ export const InitialVisit: Story = {
   },
 };
 
-export const InputWithSubmit: Story = {
-  args: { onSubmit: () => {} },
+export const InputWithSubmitButton: Story = {
+  args: { onSubmit: handleSubmit },
 };
 
-export const InitialVisitWithSubmit: Story = {
+export const InitialVisitWithSubmitButton: Story = {
   args: {
-    onSubmit: () => {},
+    onSubmit: handleSubmit,
     visit: { proposalCode: "xx", proposalNumber: 99999, number: 7 },
+  },
+};
+
+export const InitialVisitWithoutReturnKeySubmission: Story = {
+  args: {
+    onSubmit: handleSubmit,
+    visit: { proposalCode: "xx", proposalNumber: 99999, number: 7 },
+    submitOnReturn: false,
+  },
+};
+
+export const InitialVisitWithoutSubmitButton: Story = {
+  args: {
+    onSubmit: handleSubmit,
+    visit: { proposalCode: "xx", proposalNumber: 99999, number: 7 },
+    submitButton: false,
   },
 };

--- a/src/components/VisitInput.test.tsx
+++ b/src/components/VisitInput.test.tsx
@@ -8,8 +8,15 @@ it("should render visit field", () => {
   expect(getByTestId("visit-field")).toBeInTheDocument();
 });
 
-it("should render submit button", () => {
+it("should render submit button by default", () => {
   const { getByTestId } = render(<VisitInput onSubmit={() => {}} />);
+  expect(getByTestId("submit-button")).toBeInTheDocument();
+});
+
+it("should render submit button", () => {
+  const { getByTestId } = render(
+    <VisitInput onSubmit={() => {}} submitButton={true} />,
+  );
   expect(getByTestId("submit-button")).toBeInTheDocument();
 });
 
@@ -18,12 +25,19 @@ it("should render visit field without submit func", () => {
   expect(getByTestId("visit-field")).toBeInTheDocument();
 });
 
-it("should not render submit button", () => {
+it("should not render submit button by default", () => {
   const { queryByTestId } = render(<VisitInput />);
   expect(queryByTestId("submit-button")).not.toBeInTheDocument();
 });
 
-it("should produce visit and parameters on submit", () => {
+it("should not render submit button", () => {
+  const { queryByTestId } = render(
+    <VisitInput onSubmit={() => {}} submitButton={false} />,
+  );
+  expect(queryByTestId("submit-button")).not.toBeInTheDocument();
+});
+
+it("should produce visit and parameters on submit button click", () => {
   const onSubmit = jest.fn();
   const { getByTestId } = render(
     <VisitInput onSubmit={onSubmit} parameters={{ fedid: "abc98765" }} />,
@@ -44,7 +58,7 @@ it("should produce visit and parameters on submit", () => {
   );
 });
 
-it("should produce visit on submit", () => {
+it("should produce visit on submit button click", () => {
   const onSubmit = jest.fn();
   const { getByTestId } = render(<VisitInput onSubmit={onSubmit} />);
   const visitField = within(getByTestId("visit-field")).getByRole("textbox");
@@ -52,6 +66,133 @@ it("should produce visit on submit", () => {
   const submitButton = getByTestId("submit-button");
   fireEvent.click(submitButton);
   expect(onSubmit).toHaveBeenCalledWith(
+    {
+      proposalCode: "zz",
+      proposalNumber: 12345,
+      number: 7,
+    },
+    undefined,
+  );
+});
+
+it("should not produce parsed visit", () => {
+  const onSubmit = jest.fn();
+  const { getByTestId } = render(
+    <VisitInput onSubmit={onSubmit} submitOnReturn={true} />,
+  );
+  const visitField = within(getByTestId("visit-field")).getByRole("textbox");
+  fireEvent.change(visitField, { target: { value: "" } });
+  fireEvent.keyDown(visitField, {
+    key: "Enter",
+    code: "Enter",
+    keyCode: 13,
+    charCode: 13,
+  });
+  expect(onSubmit).not.toHaveBeenCalled();
+});
+
+it("should produce visit on enter key down by default", () => {
+  const onSubmit = jest.fn();
+  const { getByTestId } = render(<VisitInput onSubmit={onSubmit} />);
+  const visitField = within(getByTestId("visit-field")).getByRole("textbox");
+  fireEvent.change(visitField, { target: { value: "zz12345-7" } });
+  fireEvent.keyDown(visitField, {
+    key: "Enter",
+    code: "Enter",
+    keyCode: 13,
+    charCode: 13,
+  });
+  expect(onSubmit).toHaveBeenCalledWith(
+    {
+      proposalCode: "zz",
+      proposalNumber: 12345,
+      number: 7,
+    },
+    undefined,
+  );
+});
+
+it("should produce visit on enter key down without submit button", () => {
+  const onSubmit = jest.fn();
+  const { getByTestId } = render(
+    <VisitInput onSubmit={onSubmit} submitButton={false} />,
+  );
+  const visitField = within(getByTestId("visit-field")).getByRole("textbox");
+  fireEvent.change(visitField, { target: { value: "zz12345-7" } });
+  fireEvent.keyDown(visitField, {
+    key: "Enter",
+    code: "Enter",
+    keyCode: 13,
+    charCode: 13,
+  });
+  expect(onSubmit).toHaveBeenCalledWith(
+    {
+      proposalCode: "zz",
+      proposalNumber: 12345,
+      number: 7,
+    },
+    undefined,
+  );
+});
+
+it("should not produce visit on enter key down", () => {
+  const onSubmit = jest.fn();
+  const { getByTestId } = render(
+    <VisitInput onSubmit={onSubmit} submitOnReturn={false} />,
+  );
+  const visitField = within(getByTestId("visit-field")).getByRole("textbox");
+  fireEvent.change(visitField, { target: { value: "zz12345-7" } });
+  fireEvent.keyDown(visitField, {
+    key: "Enter",
+    code: "Enter",
+    keyCode: 13,
+    charCode: 13,
+  });
+  expect(onSubmit).not.toHaveBeenCalledWith(
+    {
+      proposalCode: "zz",
+      proposalNumber: 12345,
+      number: 7,
+    },
+    undefined,
+  );
+});
+
+it("should not produce visit on enter key down", () => {
+  const onSubmit = jest.fn();
+  const { getByTestId } = render(
+    <VisitInput onSubmit={onSubmit} submitOnReturn={false} />,
+  );
+  const visitField = within(getByTestId("visit-field")).getByRole("textbox");
+  fireEvent.change(visitField, { target: { value: "zz12345-7" } });
+  fireEvent.keyDown(visitField, {
+    key: "Enter",
+    code: "Enter",
+    keyCode: 13,
+    charCode: 13,
+  });
+  expect(onSubmit).not.toHaveBeenCalledWith(
+    {
+      proposalCode: "zz",
+      proposalNumber: 12345,
+      number: 7,
+    },
+    undefined,
+  );
+});
+
+it("should not produce visit on enter key down with no onSubmit", () => {
+  const onSubmit = jest.fn();
+  const { getByTestId } = render(<VisitInput />);
+  const visitField = within(getByTestId("visit-field")).getByRole("textbox");
+  fireEvent.change(visitField, { target: { value: "zz12345-7" } });
+  fireEvent.keyDown(visitField, {
+    key: "Enter",
+    code: "Enter",
+    keyCode: 13,
+    charCode: 13,
+  });
+  expect(onSubmit).not.toHaveBeenCalledWith(
     {
       proposalCode: "zz",
       proposalNumber: 12345,

--- a/src/components/VisitInput.tsx
+++ b/src/components/VisitInput.tsx
@@ -7,6 +7,8 @@ interface VisitInputTextProps {
   setVisitText: (v: string) => void;
   isValid: boolean;
   setIsValid: (v: boolean) => void;
+  handleSubmit?: () => void;
+  submitOnReturn?: boolean;
 }
 
 const VisitInputText: React.FC<VisitInputTextProps> = ({
@@ -14,6 +16,8 @@ const VisitInputText: React.FC<VisitInputTextProps> = ({
   setVisitText,
   isValid,
   setIsValid,
+  handleSubmit,
+  submitOnReturn,
 }) => {
   const handleInputChange = (event: ChangeEvent<HTMLInputElement>) => {
     const value = event.target.value;
@@ -21,11 +25,18 @@ const VisitInputText: React.FC<VisitInputTextProps> = ({
     setIsValid(visitRegex.test(value));
   };
 
+  const handleKeyDown = (event: { key: string }) => {
+    if (event.key === "Enter" && submitOnReturn && handleSubmit) {
+      handleSubmit();
+    }
+  };
+
   return (
     <TextField
       label="Visit"
       value={visitText}
       onChange={handleInputChange}
+      onKeyDown={handleKeyDown}
       error={!isValid}
       helperText={!isValid ? "Invalid visit" : ""}
       variant="outlined"
@@ -38,12 +49,16 @@ interface VisitInputProps {
   onSubmit?: (visit: Visit, parameters?: object) => void;
   visit?: Visit;
   parameters?: object;
+  submitButton?: boolean;
+  submitOnReturn?: boolean;
 }
 
 const VisitInput: React.FC<VisitInputProps> = ({
   onSubmit,
   visit,
   parameters,
+  submitButton = true,
+  submitOnReturn = true,
 }) => {
   const [visitText, setVisitText] = useState(visitToText(visit));
   const [isValid, setIsValid] = useState(true);
@@ -59,13 +74,15 @@ const VisitInput: React.FC<VisitInputProps> = ({
 
   return (
     <>
-      {onSubmit ? (
+      {onSubmit && submitButton ? (
         <Stack direction="row" alignContent="end" spacing={1} alignSelf="end">
           <VisitInputText
             visitText={visitText}
             setVisitText={setVisitText}
             isValid={isValid}
             setIsValid={setIsValid}
+            handleSubmit={handleSubmit}
+            submitOnReturn={submitOnReturn}
           />
           <Button
             variant="contained"
@@ -83,6 +100,8 @@ const VisitInput: React.FC<VisitInputProps> = ({
           setVisitText={setVisitText}
           isValid={isValid}
           setIsValid={setIsValid}
+          handleSubmit={handleSubmit}
+          submitOnReturn={submitOnReturn}
         />
       )}
     </>


### PR DESCRIPTION
Adds two optional parameters (`submitButton` and `submitOnReturn` ) to `VisitInput`.
`submitButton` allows the submit button to be included and is `true` by default.
`submitOnReturn` allows `onSubmit` to be called on enter key down and is `false` by default.
Also added tests, stories and a `handleSubmit` function in the story to show the behaviour.