### PR TITLE
Use named imports for MUI components

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,5 +1,10 @@
-import { Link, LinkProps, Typography, useTheme } from "@mui/material";
-import Grid from "@mui/material/Grid2";
+import {
+  Link,
+  LinkProps,
+  Typography,
+  Grid2 as Grid,
+  useTheme,
+} from "@mui/material";
 
 import React from "react";
 import {

--- a/src/components/User.tsx
+++ b/src/components/User.tsx
@@ -4,13 +4,13 @@ import {
   Button,
   Box,
   Link,
+  Menu,
+  MenuItem,
   Stack,
   Typography,
   useTheme,
 } from "@mui/material";
 
-import Menu from "@mui/material/Menu";
-import MenuItem from "@mui/material/MenuItem";
 import { ReactNode, useState } from "react";
 
 import { MdLogin } from "react-icons/md";


### PR DESCRIPTION
In some cases, using default exports can cause builds/tests to fail:

`Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: object.`

 This PR makes all MUI component imports named imports, which fixes these issues.