### PR TITLE
Only publish storybook on npm release

### DIFF
--- a/.github/workflows/deploy-storybook.yaml
+++ b/.github/workflows/deploy-storybook.yaml
@@ -2,8 +2,8 @@ name: Build and Publish storybook to GitHub Pages
 
 on:
   push:
-    branches:
-      - "main"
+    tags:
+      - v*
 jobs:
   deploy:
     environment:


### PR DESCRIPTION
Only publishes storybook version for new npm release.
This does not set up multiple storybook versions (one per release).