### PR TITLE
Add Navbar slots

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,7 @@ SciReactUI Changelog
 ### Changed
 - Breadcrumbs component takes optional linkComponent prop for page routing. 
 - Navbar, NavLink and FooterLink will use routing library for links if provided with linkComponent and to props.
+- Navbar uses slots for positioning elements. Breaking change: elements must now use rightSlot for positioning to the far right.
 
 [v0.1.0] - 2025-04-10
 ---------------------

--- a/readme.md
+++ b/readme.md
@@ -105,9 +105,13 @@ function App() {
 }
 export default App;
 ```
+The Navbar component supports multiple slot props for flexible layout customization: leftSlot, centreSlot, rightSlot.
+If a logo is defined (either via the logo prop or from the theme), the layout will arrange elements in the following order from left to right: logo, leftSlot, rightSlot.
+The centreSlot is absolutely positioned at 50% horizontally, which means it stays centered regardless of the content on the left or right. However, if the content in the left or right slots is too wide, it may overlap with the centre slot.
 
-There are various other components, here's an example of how to use the NavBar:
+Any children passed to the Navbar (NavLinks in the following example) will be placed in a horizontal Stack after the leftSlot.
 
+To control the width of the Navbar contents, containerWidth can be passed which sets the maxWidth property of a Container. This can be set to false to not constrain the contents or to a Breakpoint e.g. 'sm' where 'lg' is the default.
 ```js
 import { Container, Typography } from "@mui/material";
 import { Navbar, NavLink, NavLinks } from "@diamondlightsource/sci-react-ui";
@@ -115,17 +119,18 @@ import { Navbar, NavLink, NavLinks } from "@diamondlightsource/sci-react-ui";
 function App() {
   return (
     <>
-      <Navbar>
+      <Navbar
+        leftSlot={<Typography>left</Typography>}
+        centreSlot={<Typography>centre</Typography>}
+        rightSlot={<Typography>right</Typography>}
+        containerWidth={false}
+      >
         <NavLinks key="links">
           <NavLink href="#" key="first">
             A link
           </NavLink>
         </NavLinks>
       </Navbar>
-      <Container>
-        <Typography variant="h2">Scientific UI Collection</Typography>
-        <Typography>A collection of science based React components.</Typography>
-      </Container>
     </>
   );
 }

--- a/src/components/navigation/Navbar.stories.tsx
+++ b/src/components/navigation/Navbar.stories.tsx
@@ -19,43 +19,43 @@ type Story = StoryObj<typeof meta>;
 
 export const All: Story = {
   args: {
-    children: [
-      <NavLinks key="links">
-        <NavLink href="#Mercury" key="mercury">
-          Mercury
-        </NavLink>
-        <NavLink href="#Venus" key="venus">
-          Venus
-        </NavLink>
-        <NavLink href="#Earth" key="earth">
-          Earth
-        </NavLink>
-        <NavLink href="#Mars" key="mars">
-          Mars
-        </NavLink>
-      </NavLinks>,
-      <User
-        key="user"
-        onLogin={() => {}}
-        onLogout={() => {}}
-        user={{ name: "Name", fedid: "FedID" }}
-        color={"white"}
-      />,
-      <ColourSchemeButton key="colourScheme" />,
-    ],
+    rightSlot: (
+      <>
+        <User
+          key="user"
+          onLogin={() => {}}
+          onLogout={() => {}}
+          user={{ name: "Name", fedid: "FedID" }}
+          color={"white"}
+        />
+        <ColourSchemeButton key="colourScheme" />,
+      </>
+    ),
+    children: (
+      <>
+        <NavLinks key="links">
+          <NavLink href="#Mercury" key="mercury">
+            Mercury
+          </NavLink>
+          <NavLink href="#Venus" key="venus">
+            Venus
+          </NavLink>
+          <NavLink href="#Earth" key="earth">
+            Earth
+          </NavLink>
+          <NavLink href="#Mars" key="mars">
+            Mars
+          </NavLink>
+        </NavLinks>
+      </>
+    ),
     logo: "theme",
-  },
-};
-
-export const WithLogin: Story = {
-  args: {
-    children: <User onLogin={() => {}} onLogout={() => {}} user={null} />,
   },
 };
 
 export const WithUser: Story = {
   args: {
-    children: (
+    rightSlot: (
       <User
         key="user"
         onLogin={() => {}}
@@ -99,23 +99,27 @@ export const RouterLinks: Story = {
 
 export const LinksAndUser: Story = {
   args: {
-    children: [
-      <NavLinks key="links">
-        <NavLink href="#" key="first">
-          First
-        </NavLink>
-        <NavLink href="#" key="second">
-          Second
-        </NavLink>
-      </NavLinks>,
+    rightSlot: (
       <User
         key="user"
         onLogin={() => {}}
         onLogout={() => {}}
         user={{ name: "Name", fedid: "FedID" }}
         color={"white"}
-      />,
-    ],
+      />
+    ),
+    children: (
+      <>
+        <NavLinks key="links">
+          <NavLink href="#" key="first">
+            First
+          </NavLink>
+          <NavLink href="#" key="second">
+            Second
+          </NavLink>
+        </NavLinks>
+      </>
+    ),
   },
 };
 
@@ -174,6 +178,73 @@ export const WithNonThemeLogo: Story = {
 export const CustomChildElement: Story = {
   args: {
     children: <Chip label="Hello, World" sx={{ backgroundColor: "#aaaaaa" }} />,
+  },
+};
+
+export const LinksInSlot: Story = {
+  args: {
+    rightSlot: (
+      <>
+        <User
+          key="user"
+          onLogin={() => {}}
+          onLogout={() => {}}
+          user={{ name: "Name", fedid: "FedID" }}
+          color={"white"}
+        />
+        <ColourSchemeButton key="colourScheme" />,
+      </>
+    ),
+    leftSlot: (
+      <>
+        <NavLinks key="links">
+          <NavLink href="#Mercury" key="mercury">
+            Mercury
+          </NavLink>
+          <NavLink href="#Venus" key="venus">
+            Venus
+          </NavLink>
+          <NavLink href="#Earth" key="earth">
+            Earth
+          </NavLink>
+          <NavLink href="#Mars" key="mars">
+            Mars
+          </NavLink>
+        </NavLinks>
+      </>
+    ),
+    logo: "theme",
+  },
+};
+
+export const AllSlots: Story = {
+  args: {
+    leftSlot: (
+      <NavLink to="left" linkComponent={MockLink}>
+        Left
+      </NavLink>
+    ),
+    centreSlot: (
+      <NavLink to="centre" linkComponent={MockLink}>
+        Centre
+      </NavLink>
+    ),
+    rightSlot: (
+      <NavLink to="right" linkComponent={MockLink}>
+        Right
+      </NavLink>
+    ),
+    children: (
+      <NavLink to="children" linkComponent={MockLink}>
+        Children
+      </NavLink>
+    ),
+    logo: "theme",
+  },
+};
+export const WithLogin: Story = {
+  args: {
+    children: <User onLogin={() => {}} onLogout={() => {}} user={null} />,
   },
 };
 

--- a/src/components/navigation/Navbar.test.tsx
+++ b/src/components/navigation/Navbar.test.tsx
@@ -274,3 +274,73 @@ it("should use 'to' when both 'href' and 'to' are provided with linkComponent", 
   expect(link).toBeInTheDocument();
   expect(link).toHaveAttribute("href", "/about");
 });
+
+it("renders leftSlot", () => {
+  renderWithProviders(
+    <Navbar leftSlot={<div data-testid="left-slot">Right Slot</div>} />,
+  );
+  expect(screen.getByTestId("left-slot")).toBeInTheDocument();
+});
+
+it("renders centreSlot", () => {
+  renderWithProviders(
+    <Navbar centreSlot={<div data-testid="centre-slot">Centre Slot</div>} />,
+  );
+  expect(screen.getByTestId("centre-slot")).toBeInTheDocument();
+});
+
+it("renders rightSlot", () => {
+  renderWithProviders(
+    <Navbar rightSlot={<div data-testid="right-slot">Right Slot</div>} />,
+  );
+  expect(screen.getByTestId("right-slot")).toBeInTheDocument();
+});
+
+it("renders all slots together", () => {
+  renderWithProviders(
+    <Navbar
+      leftSlot={<div data-testid="left-slot">Right</div>}
+      centreSlot={<div data-testid="centre-slot">Centre</div>}
+      rightSlot={<div data-testid="right-slot">Right Slot</div>}
+    />,
+  );
+  expect(screen.getByTestId("left-slot")).toBeInTheDocument();
+  expect(screen.getByTestId("centre-slot")).toBeInTheDocument();
+  expect(screen.getByTestId("right-slot")).toBeInTheDocument();
+});
+describe("Navbar Slot Positioning", () => {
+  it("centreSlot should be centred", () => {
+    renderWithProviders(
+      <Navbar centreSlot={<div data-testid="centre-slot">Centre</div>} />,
+    );
+    const centreSlot = screen.getByTestId("centre-slot");
+    const parent = centreSlot.parentElement;
+    expect(parent).toHaveStyle({
+      position: "absolute",
+      left: "50%",
+      transform: "translateX(-50%)",
+    });
+  });
+
+  it("rightSlot should be aligned to the end of the row", () => {
+    renderWithProviders(
+      <Navbar rightSlot={<div data-testid="right-slot">Right</div>} />,
+    );
+    const rightSlot = screen.getByTestId("right-slot");
+    const stack = rightSlot.closest(".MuiStack-root");
+    expect(stack).toHaveStyle("justify-content: space-between");
+  });
+
+  it("logo should be vertically centred", () => {
+    renderWithProviders(
+      <Navbar
+        logo={{ src: "/logo.svg", alt: "Home" }}
+        leftSlot={<div data-testid="left-slot">Left</div>}
+      />,
+    );
+    const logo = screen.getByRole("link");
+    const logoBox = logo.parentElement;
+    expect(logoBox).toHaveStyle("display: flex");
+    expect(logoBox).toHaveStyle("align-items: center");
+  });
+});

--- a/src/components/navigation/Navbar.tsx
+++ b/src/components/navigation/Navbar.tsx
@@ -10,6 +10,7 @@ import {
   Stack,
   styled,
   useTheme,
+  Breakpoint,
 } from "@mui/material";
 import { MdMenu, MdClose } from "react-icons/md";
 import React, { useState } from "react";
@@ -25,6 +26,10 @@ interface NavLinksProps {
 interface NavbarProps extends BoxProps, React.PropsWithChildren {
   logo?: ImageColorSchemeSwitchType | "theme" | null;
   linkComponent?: React.ElementType;
+  centreSlot?: React.ReactElement<LinkProps>;
+  rightSlot?: React.ReactElement<LinkProps>;
+  leftSlot?: React.ReactElement<LinkProps>;
+  containerWidth?: false | Breakpoint;
 }
 
 interface NavLinkProps extends LinkProps {
@@ -150,7 +155,16 @@ const BoxStyled = styled(Box)<BoxProps>(({ theme }) => ({
 /**
  * Basic navigation bar. Can be used with `NavLinks` and `NavLink` to display a responsive list of links.
  */
-const Navbar = ({ children, logo, linkComponent, ...props }: NavbarProps) => {
+const Navbar = ({
+  children,
+  logo,
+  linkComponent,
+  leftSlot,
+  rightSlot,
+  centreSlot,
+  containerWidth,
+  ...props
+}: NavbarProps) => {
   const theme = useTheme();
   let resolvedLogo: ImageColorSchemeSwitchType | null | undefined = null;
   if (logo === "theme") {
@@ -161,33 +175,53 @@ const Navbar = ({ children, logo, linkComponent, ...props }: NavbarProps) => {
 
   return (
     <BoxStyled role="banner" {...props}>
-      <Container maxWidth="lg" sx={{ height: "100%" }}>
+      <Container
+        maxWidth={containerWidth}
+        sx={{
+          height: "100%",
+        }}
+      >
         <Stack
           direction="row"
-          spacing={8}
-          sx={{ height: "100%", alignItems: "center", width: "100%" }}
+          justifyContent="space-between"
+          alignItems="center"
+          height="100%"
+          width="100%"
         >
-          {resolvedLogo && (
-            <Link
-              key="logo"
-              {...(linkComponent
-                ? { component: linkComponent, to: "/" }
-                : { href: "/" })}
-            >
-              <Box
-                maxWidth="5rem"
-                sx={{
-                  "&:hover": { filter: "brightness(80%);" },
-                  marginRight: { xs: "0", md: "50px" },
-                }}
+          <Stack direction="row" alignItems="center" spacing={2}>
+            {resolvedLogo && (
+              <Link
+                key="logo"
+                {...(linkComponent
+                  ? { component: linkComponent, to: "/" }
+                  : { href: "/" })}
               >
-                <ImageColorSchemeSwitch image={resolvedLogo} />
-              </Box>
-            </Link>
-          )}
-          {children}
+                <Box
+                  maxWidth="5rem"
+                  sx={{
+                    "&:hover": { filter: "brightness(80%);" },
+                    marginRight: { xs: "0", md: "50px" },
+                  }}
+                >
+                  <ImageColorSchemeSwitch image={resolvedLogo} />
+                </Box>
+              </Link>
+            )}
+            {leftSlot}
+            {children}
+          </Stack>
+          {rightSlot}
         </Stack>
       </Container>
+      <Box
+        sx={{
+          position: "absolute",
+          left: "50%",
+          transform: "translateX(-50%)",
+        }}
+      >
+        {centreSlot}
+      </Box>
     </BoxStyled>
   );
 };


### PR DESCRIPTION
Adds slots to Navbar: `logoLeftSlot`, `logoRightSlot`, `centreSlot`, `rightSlot`.
If a logo is defined (either via the `logo` prop or from the theme), the layout will arrange elements in the following order from left to right: `logoLeftSlot`, `logo`, `logoRightSlot`, `rightSlot`.
The `centreSlot` is absolutely positioned at 50% horizontally, which means it stays centered regardless of the content on the left or right. However, if the content in the left or right slots is too wide, it may overlap with the centre slot.

Existing uses of Navbar will need to update anything on the far right to be in `rightSlot`. Children should behave as before. By changing slot props, there should be a lot more freedom over the layout. 