### PR TITLE
Logo component to be used anywhere.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,10 +6,11 @@ SciReactUI Changelog
 --------------------
 
 ### Added
--
+- Logo component
 
 ### Fixed
 - Styles added to Navbar and Footer incorrectly remove built in styles.
+- Logo not appearing when no dark src set in dark mode.
 
 ### Changed
 - Breadcrumbs component takes optional linkComponent prop for page routing. 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@diamondlightsource/sci-react-ui",
-  "version": "0.2",
+  "version": "0.2.0alpha",
   "description": "A theme and component library to make websites at scientific institutions simple to create.",
   "author": "Diamond Light Source",
   "license": "ISC",

--- a/src/__test-utils__/helpers.tsx
+++ b/src/__test-utils__/helpers.tsx
@@ -5,11 +5,11 @@ import { ThemeProviderProps } from "@mui/material/styles/ThemeProvider";
 
 export const renderWithProviders = (
   ui: React.ReactNode,
-  themeOptions?: Omit<ThemeProviderProps, "theme">,
+  themeOptions?: ThemeProviderProps,
 ): RenderResult => {
   const Wrapper = ({ children }: { children: React.ReactNode }) => {
     return (
-      <ThemeProvider {...themeOptions} theme={DiamondTheme}>
+      <ThemeProvider theme={DiamondTheme} {...themeOptions} >
         {children}
       </ThemeProvider>
     );

--- a/src/components/controls/ImageColorSchemeSwitch.test.tsx
+++ b/src/components/controls/ImageColorSchemeSwitch.test.tsx
@@ -7,6 +7,7 @@ import { screen } from "@testing-library/react";
 describe("ImageColorSchemeSwitch", () => {
   const testVals = {
     src: "src/light",
+    srcDark: "src/dark",
     alt: "test-alt",
   };
 
@@ -59,14 +60,23 @@ describe("ImageColorSchemeSwitch", () => {
   });
 
   it("should have alternate src", () => {
-    const srcDark = "src/dark";
 
     renderWithProviders(
-      <ImageColorSchemeSwitch image={{ ...testVals, srcDark }} />,
+      <ImageColorSchemeSwitch image={{ ...testVals }} />,
       { defaultMode: "dark" },
     );
     const img = screen.getByTestId("image-dark");
-
-    expect(img).toHaveAttribute("src", srcDark);
+    expect(img).toHaveAttribute("src", testVals.srcDark);
   });
+  
+  it("should have src when no srcDark set but dark mode selected", () => {
+    
+    renderWithProviders(
+      <ImageColorSchemeSwitch image={{ ...testVals }} />,
+      { defaultMode: "dark" },
+    );
+    const img = screen.getByRole("img");
+    expect(img).toHaveAttribute("src", testVals.src);
+  });
+  
 });

--- a/src/components/controls/ImageColorSchemeSwitch.tsx
+++ b/src/components/controls/ImageColorSchemeSwitch.tsx
@@ -1,4 +1,5 @@
 import { styled } from "@mui/material";
+import React from "react";
 
 type ImageColorSchemeSwitchType = {
   src: string;
@@ -8,8 +9,9 @@ type ImageColorSchemeSwitchType = {
   height?: string;
 };
 
-interface ImageColorSchemeSwitchProps {
+interface ImageColorSchemeSwitchProps  {
   image: ImageColorSchemeSwitchType;
+  style?: React.CSSProperties;
 }
 
 /** Styled component which is only displayed in dark mode */
@@ -28,23 +30,35 @@ const ImageLight = styled("img")(({ theme }) => [
   }),
 ]);
 
-const ImageColorSchemeSwitch = ({ image }: ImageColorSchemeSwitchProps) => (
-  <>
-    <ImageLight
-      data-testid="image-light"
+const ImageColorSchemeSwitch = ({ image, style }: ImageColorSchemeSwitchProps) => (
+  image.srcDark ? (
+    <>
+      <ImageLight
+        data-testid="image-light"
+        src={image.src}
+        alt={image.alt}
+        width={image.width}
+        height={image.height}
+        style={style}
+      />
+      <ImageDark
+        data-testid="image-dark"
+        src={image.srcDark}
+        alt={image.alt}
+        width={image.width}
+        height={image.height}
+        style={style}
+      />
+    </>
+  ) : (
+    <img
       src={image.src}
       alt={image.alt}
       width={image.width}
       height={image.height}
+      style={style}
     />
-    <ImageDark
-      data-testid="image-dark"
-      src={image.srcDark}
-      alt={image.alt}
-      width={image.width}
-      height={image.height}
-    />
-  </>
+  )
 );
 
 export { ImageColorSchemeSwitch };

--- a/src/components/controls/Logo.stories.tsx
+++ b/src/components/controls/Logo.stories.tsx
@@ -1,0 +1,43 @@
+import { Meta, StoryObj } from "@storybook/react";
+import { Logo } from "./Logo";
+
+const meta: Meta<typeof Logo> = {
+  title: "SciReactUI/Control/Logo",
+  component: Logo,
+  tags: ["autodocs"],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Show the logo associated with the theme",
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const TheLogo: Story = {
+  args: {},
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "The normally sized logo",
+      },
+    },
+  },
+};
+
+export const TheShortLogo: Story = {
+  args: { short: true },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "The shorter image.",
+      },
+    },
+  },
+};

--- a/src/components/controls/Logo.test.tsx
+++ b/src/components/controls/Logo.test.tsx
@@ -1,0 +1,59 @@
+import "@testing-library/jest-dom";
+import { screen } from "@testing-library/react";
+import {createTheme, Theme} from "@mui/material/styles";
+
+import { renderWithProviders } from "../../__test-utils__/helpers";
+import {BaseThemeOptions} from "../../themes/BaseTheme";
+
+import { Logo } from "./Logo";
+
+describe("Logo", () => {
+  
+  const src = "a/test/src";
+  const TestTheme: Theme = createTheme({
+    ...BaseThemeOptions,
+    logos: {
+      normal: {
+        src,
+        alt: "alt",
+      },
+      short: {
+        src: src + "/short",
+        alt: "alt"
+      },
+    },
+  });
+  
+  function render( logo:any ) {
+    renderWithProviders(logo, {theme:TestTheme} );
+  }
+  
+  it("should render without errors", () => {
+    render(<Logo />)
+  });
+
+  it("should have am img", () => {
+    render(<Logo /> );
+    const img = screen.getByRole("img");
+    
+    expect(img).toBeInTheDocument();
+    expect(img).toHaveAttribute("src", src)
+  });
+  
+  it("should have an img when short", () => {
+    render(<Logo short={true} />);
+    
+    const img = screen.getByRole("img");
+    expect(img).toBeInTheDocument();
+    expect(img).toHaveAttribute("src", src + "/short")
+  });
+  
+  it("should have a margin", () => {
+    render(<Logo style={{margin:"10px"}} />);
+    
+    const img = screen.getByRole("img");
+    expect(img).toBeInTheDocument();
+    expect(img).toHaveAttribute("style", "margin: 10px;")
+  });
+  
+});

--- a/src/components/controls/Logo.tsx
+++ b/src/components/controls/Logo.tsx
@@ -1,0 +1,18 @@
+import {BoxProps, styled, useTheme} from "@mui/material";
+import {ImageColorSchemeSwitch, ImageColorSchemeSwitchType} from "./ImageColorSchemeSwitch";
+import React from "react";
+
+interface LogoProps extends BoxProps {
+	short?: boolean,
+	style?: React.CSSProperties;
+}
+
+const Logo = ({ short=false, style } :LogoProps) => {
+	
+	const theme = useTheme();
+	const logo = (short !== undefined && short) ? theme.logos?.short : theme.logos?.normal
+	
+	return ( logo && <ImageColorSchemeSwitch style={style} image={logo}/> )
+};
+
+export { Logo };

--- a/src/components/navigation/Footer.stories.tsx
+++ b/src/components/navigation/Footer.stories.tsx
@@ -70,7 +70,6 @@ export const LogoOnly: Story = {
 
 export const CopyrightOnly: Story = {
   args: {
-    logo: null,
     copyright: "Company",
   },
 };

--- a/src/components/navigation/Footer.tsx
+++ b/src/components/navigation/Footer.tsx
@@ -14,13 +14,14 @@ import {
   ImageColorSchemeSwitch,
   ImageColorSchemeSwitchType,
 } from "../controls/ImageColorSchemeSwitch";
+import {Logo} from "../controls/Logo";
 
 interface FooterLinksProps extends React.HTMLProps<HTMLDivElement> {
   children: React.ReactElement<LinkProps> | React.ReactElement<LinkProps>[];
 }
 
 interface FooterProps extends BoxProps, React.PropsWithChildren {
-  logo?: ImageColorSchemeSwitchType | "theme" | null;
+  logo?: ImageColorSchemeSwitchType | "theme";
   copyright?: string | null;
 }
 
@@ -102,20 +103,13 @@ const BoxStyled = styled(Box)<BoxProps>(({ theme }) => ({
  */
 const Footer = ({ logo, copyright, children, ...props }: FooterProps) => {
   const theme = useTheme();
-  let resolvedLogo: ImageColorSchemeSwitchType | null | undefined = null;
-
-  if (logo === "theme") {
-    resolvedLogo = theme.logos?.short;
-  } else if (logo && typeof logo === "object") {
-    resolvedLogo = logo;
-  }
 
   return (
     <BoxStyled role="contentinfo" {...props}>
       <Grid container>
         <Grid
           size={
-            resolvedLogo || copyright ? { xs: 6, md: 8 } : { xs: 12, md: 12 }
+            logo || copyright ? { xs: 6, md: 8 } : { xs: 12, md: 12 }
           }
           style={{
             alignContent: "center",
@@ -131,7 +125,7 @@ const Footer = ({ logo, copyright, children, ...props }: FooterProps) => {
           </div>
         </Grid>
 
-        {(resolvedLogo || copyright) && (
+        {(logo || copyright) && (
           <Grid size={{ xs: 6, md: 4 }}>
             <div
               style={{
@@ -141,7 +135,7 @@ const Footer = ({ logo, copyright, children, ...props }: FooterProps) => {
                 textAlign: "right",
               }}
             >
-              {resolvedLogo && <ImageColorSchemeSwitch image={resolvedLogo} />}
+              {logo && (logo=="theme" ? <Logo short={true} /> : <ImageColorSchemeSwitch image={logo} />)}
               {copyright && (
                 <Typography
                   style={{

--- a/src/components/navigation/Navbar.stories.tsx
+++ b/src/components/navigation/Navbar.stories.tsx
@@ -7,6 +7,7 @@ import logoImageLight from "../../public/generic/logo-light.svg";
 import { ColourSchemeButton } from "../controls/ColourSchemeButton";
 import { User } from "../controls/User";
 import { MockLink } from "../../utils/MockLink";
+import {Logo} from "../controls/Logo";
 
 const meta: Meta<typeof Navbar> = {
   title: "SciReactUI/Navigation/Navbar",
@@ -170,6 +171,31 @@ export const WithNonThemeLogo: Story = {
     docs: {
       description: {
         story: "A separate image can also be referenced.",
+      },
+    },
+  },
+};
+
+
+export const WithThemeLogoAsChild: Story = {
+  args: {
+    children: (<>
+        <NavLinks key="links">
+          <NavLink href="#" key="first">
+            First
+          </NavLink>
+          <NavLink href="#" key="second">
+            Second
+          </NavLink>
+        </NavLinks>
+        <Logo style={{marginRight:"100px", transform: "rotateX(180deg)"}} />
+      </>
+    )
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "You can pass the logo in as a child instead of part of the Navbar for full control.",
       },
     },
   },

--- a/src/components/navigation/Navbar.test.tsx
+++ b/src/components/navigation/Navbar.test.tsx
@@ -1,3 +1,5 @@
+// noinspection JSConstantReassignment
+
 import { fireEvent, screen } from "@testing-library/react";
 import { Navbar, NavLinks, NavLink } from "./Navbar";
 import "@testing-library/jest-dom";
@@ -27,9 +29,9 @@ describe("Navbar", () => {
 });
 
 describe("Navbar Logo", () => {
-  it("should not display logo if null", () => {
+  it("should not display logo if undefined", () => {
     global.innerWidth = 600;
-    renderWithProviders(<Navbar logo={null} />);
+    renderWithProviders(<Navbar />);
     expect(screen.queryByAltText("Home")).not.toBeInTheDocument();
   });
 });
@@ -129,11 +131,8 @@ it("should render logo with correct alt text", () => {
     </MemoryRouter>,
   );
 
-  const lightLogo = screen.getByTestId("image-light");
-  const darkLogo = screen.getByTestId("image-dark");
-
-  expect(lightLogo).toHaveAttribute("alt", "Home");
-  expect(darkLogo).toHaveAttribute("alt", "Home");
+  const logo = screen.getByRole("img");
+  expect(logo).toHaveAttribute("alt", "Home");
 });
 
 it("should render NavLink without crashing when no 'to' or 'href' is provided", () => {
@@ -183,12 +182,10 @@ it("should render NavLink with linkComponent and 'to' prop", () => {
 it("should render logo with href when linkComponent is not provided", () => {
   renderWithProviders(<Navbar logo={{ src: "/logo.svg", alt: "Home" }} />);
 
-  const lightLogo = screen.getByTestId("image-light");
-  const darkLogo = screen.getByTestId("image-dark");
+  const logo = screen.getByRole("img");
   const logoLink = screen.getByRole("link");
 
-  expect(lightLogo).toHaveAttribute("alt", "Home");
-  expect(darkLogo).toHaveAttribute("alt", "Home");
+  expect(logo).toHaveAttribute("alt", "Home");
   expect(logoLink).toHaveAttribute("href", "/");
 });
 
@@ -200,12 +197,11 @@ it("should render logo with linkComponent without 'to' prop", () => {
   );
 
   const logoLink = screen.getByRole("link");
-  const lightLogo = screen.getByTestId("image-light");
-  const darkLogo = screen.getByTestId("image-dark");
+  const logo = screen.getByRole("img");
 
-  expect(lightLogo).toHaveAttribute("alt", "Home");
-  expect(darkLogo).toHaveAttribute("alt", "Home");
+  expect(logo).toHaveAttribute("alt", "Home");
   expect(logoLink).toHaveAttribute("href", "/");
+  expect(logoLink).not.toHaveAttribute("to");
 });
 
 it("should not render a valid link when only 'to' is provided without linkComponent", () => {

--- a/src/components/navigation/Navbar.tsx
+++ b/src/components/navigation/Navbar.tsx
@@ -18,13 +18,14 @@ import {
   ImageColorSchemeSwitch,
   ImageColorSchemeSwitchType,
 } from "../controls/ImageColorSchemeSwitch";
+import {Logo} from "../controls/Logo";
 
 interface NavLinksProps {
   children: React.ReactElement<LinkProps> | React.ReactElement<LinkProps>[];
 }
 
 interface NavbarProps extends BoxProps, React.PropsWithChildren {
-  logo?: ImageColorSchemeSwitchType | "theme" | null;
+  logo?: ImageColorSchemeSwitchType | "theme";
   linkComponent?: React.ElementType;
   centreSlot?: React.ReactElement<LinkProps>;
   rightSlot?: React.ReactElement<LinkProps>;
@@ -166,12 +167,6 @@ const Navbar = ({
   ...props
 }: NavbarProps) => {
   const theme = useTheme();
-  let resolvedLogo: ImageColorSchemeSwitchType | null | undefined = null;
-  if (logo === "theme") {
-    resolvedLogo = theme.logos?.normal;
-  } else if (logo && typeof logo === "object") {
-    resolvedLogo = logo;
-  }
 
   return (
     <BoxStyled role="banner" {...props}>
@@ -189,7 +184,7 @@ const Navbar = ({
           width="100%"
         >
           <Stack direction="row" alignItems="center" spacing={2}>
-            {resolvedLogo && (
+            {logo && (
               <Link
                 key="logo"
                 {...(linkComponent
@@ -203,7 +198,7 @@ const Navbar = ({
                     marginRight: { xs: "0", md: "50px" },
                   }}
                 >
-                  <ImageColorSchemeSwitch image={resolvedLogo} />
+	                {logo == "theme" ? <Logo /> : <ImageColorSchemeSwitch image={logo} />}
                 </Box>
               </Link>
             )}

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,14 +6,15 @@ export * from "./components/navigation/Navbar";
 
 // components/controls
 export * from "./components/controls/ColourSchemeButton";
+export * from "./components/controls/ImageColorSchemeSwitch";
+export * from "./components/controls/Logo";
 export * from "./components/controls/User";
 export * from "./components/controls/VisitInput";
-export * from "./components/controls/ImageColorSchemeSwitch";
 
 // themes
 export * from "./themes/BaseTheme";
-export * from "./themes/GenericTheme";
 export * from "./themes/DiamondTheme";
+export * from "./themes/GenericTheme";
 export * from "./themes/ThemeProvider";
 
 // utils

--- a/src/themes/DiamondTheme.ts
+++ b/src/themes/DiamondTheme.ts
@@ -22,7 +22,7 @@ const DiamondTheme: Theme = createTheme({
     short: {
       src: logoShort,
       alt: "Diamond Source Logo",
-      width: "65",
+      width: "35",
     },
   },
   colorSchemes: {


### PR DESCRIPTION
Here's the logo component. I've used this component where the logo was being used, and it's somewhat simplified bits of code.

You can use it with `<Logo/>` or `<Logo short={true}/>`.
