### PR TITLE
Rename color to colour

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,18 @@ SciReactUI Changelog
 ====================
 
 
+[v0.2.1alpha] - 2025-??-??
+--------------------
+
+### Added
+-
+
+### Fixed
+- 
+
+### Changed
+- Breaking changes: ImageColorSchemeSwitch, ImageColorSchemeSwitchType and ImageColorSchemeSwitchProps renamed to ImageColourSchemeSwitch, ImageColourSchemeSwitchType and ImageColourSchemeSwitchProps. User component color prop renamed to colour.
+
 [v0.2.0] - 2025-06-11
 ---------------------
 

--- a/src/components/controls/ColourSchemeButton.stories.tsx
+++ b/src/components/controls/ColourSchemeButton.stories.tsx
@@ -2,7 +2,7 @@ import { Meta, StoryObj } from "@storybook/react";
 import { ColourSchemeButton } from "./ColourSchemeButton";
 
 const meta: Meta<typeof ColourSchemeButton> = {
-  title: "SciReactUI/Control/ColorSchemeButton",
+  title: "SciReactUI/Control/ColourSchemeButton",
   component: ColourSchemeButton,
   tags: ["autodocs"],
   parameters: {

--- a/src/components/controls/ImageColourSchemeSwitch.stories.tsx
+++ b/src/components/controls/ImageColourSchemeSwitch.stories.tsx
@@ -1,18 +1,18 @@
 import { Meta, StoryObj } from "@storybook/react";
-import { ImageColorSchemeSwitch } from "./ImageColorSchemeSwitch";
+import { ImageColourSchemeSwitch } from "./ImageColourSchemeSwitch";
 
 import imageDark from "../../public/generic/logo-dark.svg";
 import imageLight from "../../public/generic/logo-light.svg";
 
-const meta: Meta<typeof ImageColorSchemeSwitch> = {
-  title: "SciReactUI/Control/ImageColorSchemeSwitch",
-  component: ImageColorSchemeSwitch,
+const meta: Meta<typeof ImageColourSchemeSwitch> = {
+  title: "SciReactUI/Control/ImageColourSchemeSwitch",
+  component: ImageColourSchemeSwitch,
   tags: ["autodocs"],
   parameters: {
     docs: {
       description: {
         component:
-          "Switch between an image depending on the color scheme mode, light or dark versions",
+          "Switch between an image depending on the colour scheme mode, light or dark versions",
       },
     },
   },
@@ -34,7 +34,7 @@ export const SwitchingImage: Story = {
     docs: {
       description: {
         story:
-          "This image changes depending on the color scheme mode selected.",
+          "This image changes depending on the colour scheme mode selected.",
       },
     },
   },
@@ -63,7 +63,7 @@ export const NonSwitchingImage: Story = {
     docs: {
       description: {
         story:
-          "This image only has a single src so will NOT switch when the color scheme mode switches.",
+          "This image only has a single src so will NOT switch when the colour scheme mode switches.",
       },
     },
   },

--- a/src/components/controls/ImageColourSchemeSwitch.test.tsx
+++ b/src/components/controls/ImageColourSchemeSwitch.test.tsx
@@ -1,10 +1,10 @@
 import "@testing-library/jest-dom";
 
-import { ImageColorSchemeSwitch } from "./ImageColorSchemeSwitch";
+import { ImageColourSchemeSwitch } from "./ImageColourSchemeSwitch";
 import { renderWithProviders } from "../../__test-utils__/helpers";
 import { screen } from "@testing-library/react";
 
-describe("ImageColorSchemeSwitch", () => {
+describe("ImageColourSchemeSwitch", () => {
   const testVals = {
     src: "src/light",
     alt: "test-alt",
@@ -18,7 +18,7 @@ describe("ImageColorSchemeSwitch", () => {
     height?: string;
   }) {
     const { getByTestId } = renderWithProviders(
-      <ImageColorSchemeSwitch image={{ ...testVals, ...image }} />,
+      <ImageColourSchemeSwitch image={{ ...testVals, ...image }} />,
     );
 
     const img = getByTestId("image-light");
@@ -27,7 +27,7 @@ describe("ImageColorSchemeSwitch", () => {
   }
 
   it("should render without errors", () => {
-    renderWithProviders(<ImageColorSchemeSwitch image={{ ...testVals }} />);
+    renderWithProviders(<ImageColourSchemeSwitch image={{ ...testVals }} />);
   });
 
   it("should have src and alt by default", () => {
@@ -62,7 +62,7 @@ describe("ImageColorSchemeSwitch", () => {
     const srcDark = "src/dark";
 
     renderWithProviders(
-      <ImageColorSchemeSwitch image={{ ...testVals, srcDark }} />,
+      <ImageColourSchemeSwitch image={{ ...testVals, srcDark }} />,
       { defaultMode: "dark" },
     );
     const img = screen.getByTestId("image-dark");

--- a/src/components/controls/ImageColourSchemeSwitch.tsx
+++ b/src/components/controls/ImageColourSchemeSwitch.tsx
@@ -1,6 +1,6 @@
 import { styled } from "@mui/material";
 
-type ImageColorSchemeSwitchType = {
+type ImageColourSchemeSwitchType = {
   src: string;
   srcDark?: string;
   alt: string;
@@ -8,8 +8,8 @@ type ImageColorSchemeSwitchType = {
   height?: string;
 };
 
-interface ImageColorSchemeSwitchProps {
-  image: ImageColorSchemeSwitchType;
+interface ImageColourSchemeSwitchProps {
+  image: ImageColourSchemeSwitchType;
 }
 
 /** Styled component which is only displayed in dark mode */
@@ -28,7 +28,7 @@ const ImageLight = styled("img")(({ theme }) => [
   }),
 ]);
 
-const ImageColorSchemeSwitch = ({ image }: ImageColorSchemeSwitchProps) => (
+const ImageColourSchemeSwitch = ({ image }: ImageColourSchemeSwitchProps) => (
   <>
     <ImageLight
       data-testid="image-light"
@@ -47,5 +47,5 @@ const ImageColorSchemeSwitch = ({ image }: ImageColorSchemeSwitchProps) => (
   </>
 );
 
-export { ImageColorSchemeSwitch };
-export type { ImageColorSchemeSwitchProps, ImageColorSchemeSwitchType };
+export { ImageColourSchemeSwitch };
+export type { ImageColourSchemeSwitchProps, ImageColourSchemeSwitchType };

--- a/src/components/controls/User.stories.tsx
+++ b/src/components/controls/User.stories.tsx
@@ -31,9 +31,9 @@ export const LoggedInLongName: Story = {
   },
 };
 
-export const LoggedInChangeColor: Story = {
+export const LoggedInChangeColour: Story = {
   args: {
-    color: "red",
+    colour: "red",
     user: { name: "Name Surname", fedid: "abc12345" },
     onLogout: () => {},
   },

--- a/src/components/controls/User.tsx
+++ b/src/components/controls/User.tsx
@@ -25,7 +25,7 @@ interface UserProps {
   onLogin?: () => void;
   onLogout?: () => void;
   avatar?: ReactNode;
-  color?: string;
+  colour?: string;
   menuItems?: ReactElement<typeof MenuItem> | ReactElement<typeof MenuItem>[];
 }
 
@@ -34,7 +34,7 @@ const User = ({
   onLogin,
   onLogout,
   avatar,
-  color,
+  colour,
   menuItems,
 }: UserProps) => {
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
@@ -82,7 +82,7 @@ const User = ({
                   variant="rounded"
                   sx={{
                     backgroundColor: theme.vars.palette.primary.light,
-                    color: color || "textPrimary",
+                    color: colour || "textPrimary",
                     height: 35,
                     width: 35,
                   }}
@@ -99,7 +99,7 @@ const User = ({
                   textTransform="none"
                   textAlign="left"
                   pl={"1px"}
-                  color={color || "textPrimary"}
+                  color={colour || "textPrimary"}
                 >
                   {user.name ? user.name : user.fedid}
                 </Typography>
@@ -109,7 +109,7 @@ const User = ({
                     textTransform="none"
                     textAlign="left"
                     pl={"1px"}
-                    color={color || "textPrimary"}
+                    color={colour || "textPrimary"}
                   >
                     {user.fedid}
                   </Typography>

--- a/src/components/navigation/Breadcrumbs.stories.tsx
+++ b/src/components/navigation/Breadcrumbs.stories.tsx
@@ -66,7 +66,7 @@ export const NoLinkComponentWithCustomPath: Story = {
   },
 };
 
-export const ColorChange: Story = {
+export const ColourChange: Story = {
   args: {
     path: ["first", "second", "third", "last"],
     linkComponent: MockLink,

--- a/src/components/navigation/Footer.test.tsx
+++ b/src/components/navigation/Footer.test.tsx
@@ -1,10 +1,10 @@
-import type { ImageColorSchemeSwitchType } from "../controls/ImageColorSchemeSwitch";
-jest.mock("../controls/ImageColorSchemeSwitch", () => ({
+import type { ImageColourSchemeSwitchType } from "../controls/ImageColourSchemeSwitch";
+jest.mock("../controls/ImageColourSchemeSwitch", () => ({
   __esModule: true,
-  ImageColorSchemeSwitch: ({
+  ImageColourSchemeSwitch: ({
     image,
   }: {
-    image: ImageColorSchemeSwitchType;
+    image: ImageColourSchemeSwitchType;
   }) => (
     <img src={image.src} alt={image.alt} role="img" data-testid="mock-logo" />
   ),

--- a/src/components/navigation/Footer.tsx
+++ b/src/components/navigation/Footer.tsx
@@ -12,16 +12,16 @@ import {
 
 import React from "react";
 import {
-  ImageColorSchemeSwitch,
-  ImageColorSchemeSwitchType,
-} from "../controls/ImageColorSchemeSwitch";
+  ImageColourSchemeSwitch,
+  ImageColourSchemeSwitchType,
+} from "../controls/ImageColourSchemeSwitch";
 
 interface FooterLinksProps extends React.HTMLProps<HTMLDivElement> {
   children: React.ReactElement<LinkProps> | React.ReactElement<LinkProps>[];
 }
 
 interface FooterProps extends BoxProps, React.PropsWithChildren {
-  logo?: ImageColorSchemeSwitchType | "theme" | null;
+  logo?: ImageColourSchemeSwitchType | "theme" | null;
   copyright?: string | null;
   centreSlot?: React.ReactElement<LinkProps>;
   rightSlot?: React.ReactElement<LinkProps>;
@@ -116,7 +116,7 @@ const Footer = ({
   ...props
 }: FooterProps) => {
   const theme = useTheme();
-  let resolvedLogo: ImageColorSchemeSwitchType | null | undefined = null;
+  let resolvedLogo: ImageColourSchemeSwitchType | null | undefined = null;
 
   if (logo === "theme") {
     resolvedLogo = theme.logos?.short;
@@ -177,7 +177,7 @@ const Footer = ({
                 textAlign: "right",
               }}
             >
-              {resolvedLogo && <ImageColorSchemeSwitch image={resolvedLogo} />}
+              {resolvedLogo && <ImageColourSchemeSwitch image={resolvedLogo} />}
               {copyright && (
                 <Typography
                   style={{

--- a/src/components/navigation/Navbar.stories.tsx
+++ b/src/components/navigation/Navbar.stories.tsx
@@ -26,7 +26,7 @@ export const All: Story = {
           onLogin={() => {}}
           onLogout={() => {}}
           user={{ name: "Name", fedid: "FedID" }}
-          color={"white"}
+          colour={"white"}
         />
         <ColourSchemeButton key="colourScheme" />,
       </>
@@ -61,7 +61,7 @@ export const WithUser: Story = {
         onLogin={() => {}}
         onLogout={() => {}}
         user={{ name: "Name", fedid: "FedID" }}
-        color={"white"}
+        colour={"white"}
       />
     ),
   },
@@ -105,7 +105,7 @@ export const LinksAndUser: Story = {
         onLogin={() => {}}
         onLogout={() => {}}
         user={{ name: "Name", fedid: "FedID" }}
-        color={"white"}
+        colour={"white"}
       />
     ),
     children: (
@@ -190,7 +190,7 @@ export const LinksInSlot: Story = {
           onLogin={() => {}}
           onLogout={() => {}}
           user={{ name: "Name", fedid: "FedID" }}
-          color={"white"}
+          colour={"white"}
         />
         <ColourSchemeButton key="colourScheme" />,
       </>

--- a/src/components/navigation/Navbar.tsx
+++ b/src/components/navigation/Navbar.tsx
@@ -15,16 +15,16 @@ import {
 import { MdMenu, MdClose } from "react-icons/md";
 import React, { useState } from "react";
 import {
-  ImageColorSchemeSwitch,
-  ImageColorSchemeSwitchType,
-} from "../controls/ImageColorSchemeSwitch";
+  ImageColourSchemeSwitch,
+  ImageColourSchemeSwitchType,
+} from "../controls/ImageColourSchemeSwitch";
 
 interface NavLinksProps {
   children: React.ReactElement<LinkProps> | React.ReactElement<LinkProps>[];
 }
 
 interface NavbarProps extends BoxProps, React.PropsWithChildren {
-  logo?: ImageColorSchemeSwitchType | "theme" | null;
+  logo?: ImageColourSchemeSwitchType | "theme" | null;
   linkComponent?: React.ElementType;
   centreSlot?: React.ReactElement<LinkProps>;
   rightSlot?: React.ReactElement<LinkProps>;
@@ -166,7 +166,7 @@ const Navbar = ({
   ...props
 }: NavbarProps) => {
   const theme = useTheme();
-  let resolvedLogo: ImageColorSchemeSwitchType | null | undefined = null;
+  let resolvedLogo: ImageColourSchemeSwitchType | null | undefined = null;
   if (logo === "theme") {
     resolvedLogo = theme.logos?.normal;
   } else if (logo && typeof logo === "object") {
@@ -203,7 +203,7 @@ const Navbar = ({
                     marginRight: { xs: "0", md: "50px" },
                   }}
                 >
-                  <ImageColorSchemeSwitch image={resolvedLogo} />
+                  <ImageColourSchemeSwitch image={resolvedLogo} />
                 </Box>
               </Link>
             )}

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ export * from "./components/navigation/Navbar";
 export * from "./components/controls/ColourSchemeButton";
 export * from "./components/controls/User";
 export * from "./components/controls/VisitInput";
-export * from "./components/controls/ImageColorSchemeSwitch";
+export * from "./components/controls/ImageColourSchemeSwitch";
 
 // themes
 export * from "./themes/BaseTheme";

--- a/src/storybook/theme/Logos.mdx
+++ b/src/storybook/theme/Logos.mdx
@@ -1,5 +1,5 @@
-import { Meta, ColorPalette, ColorItem } from '@storybook/blocks';
-import {ImageColorSchemeSwitch} from "../../components/controls/ImageColorSchemeSwitch";
+import { Meta, ColorPalette, ColorItem } from "@storybook/blocks";
+import { ImageColourSchemeSwitch } from "../../components/controls/ImageColourSchemeSwitch";
 
 <Meta title="Theme/Logos" />
 
@@ -7,9 +7,9 @@ import {ImageColorSchemeSwitch} from "../../components/controls/ImageColorScheme
 	<div className='sb-section-title'>
 		# Logos
 
-		Logos can be added to new themes by adding to the `createTheme` call:
+    	Logos can be added to new themes by adding to the `createTheme` call:
 
-		```js
+    	```js
         {
         ...
             logos: {
@@ -22,46 +22,47 @@ import {ImageColorSchemeSwitch} from "../../components/controls/ImageColorScheme
             },
         ...
         }
-		```
+    	```
 
-        <ImageColorSchemeSwitch image={{"src":"static/media/src/public/generic/logo-light.svg","alt":"A Logo"}}/>
+        <ImageColourSchemeSwitch image={{"src":"static/media/src/public/generic/logo-light.svg","alt":"A Logo"}}/>
 
         ## Sizes
-		There are two image sizes. I regular `normal` and a smaller version `short`, these are used in the Navbar and
-		the Footer, respectively.
+    	There are two image sizes. I regular `normal` and a smaller version `short`, these are used in the Navbar and
+    	the Footer, respectively.
 
-        ## Switch with Color Scheme
-		You can also switch them based on the current ColorScheme by adding an additional `srcDark` option.
+        ## Switch with Colour Scheme
+    	You can also switch them based on the current colour scheme by adding an additional `srcDark` option.
 
-		```js
-		import logo from "my-images/logo.svg"
-		import logoDark from "my-images/logo-dark.svg"
+    	```js
+    	import logo from "my-images/logo.svg"
+    	import logoDark from "my-images/logo-dark.svg"
 
-		logos: {
-			normal: {
-				src: logo,
-				srcDark: logoDark,
-				alt: "My Logo"
-			},
-		},
-			```
+    	logos: {
+    		normal: {
+    			src: logo,
+    			srcDark: logoDark,
+    			alt: "My Logo"
+    		},
+    	},
+    		```
 
         ## Theme
-		To create a new theme with your logos:
-		```js
+    	To create a new theme with your logos:
+    	```js
         import { createTheme } from "@mui/material/styles";
         import { BaseThemeOptions } from "./BaseTheme";
         import logo "my-images/logo.svg"
 
-		const MyTheme = createTheme({
-			...BaseThemeOptions,
-			logos: {
-				normal: {
-					src: logo,
-					alt: "My Logo"
-				}
-			},
-		},
-		```
-	</div>
+    	const MyTheme = createTheme({
+    		...BaseThemeOptions,
+    		logos: {
+    			normal: {
+    				src: logo,
+    				alt: "My Logo"
+    			}
+    		},
+    	},
+    	```
+    </div>
+
 </div>

--- a/src/themes/BaseTheme.ts
+++ b/src/themes/BaseTheme.ts
@@ -1,18 +1,18 @@
 // import {ThemeOptions} from "@mui/material/styles";
-import { ImageColorSchemeSwitchType } from "../components/controls/ImageColorSchemeSwitch";
+import { ImageColourSchemeSwitchType } from "../components/controls/ImageColourSchemeSwitch";
 
 // Make additions to theme, so that anything can be available throughout the app
 declare module "@mui/material/styles" {
   interface Theme {
     logos?: {
-      normal: ImageColorSchemeSwitchType;
-      short?: ImageColorSchemeSwitchType;
+      normal: ImageColourSchemeSwitchType;
+      short?: ImageColourSchemeSwitchType;
     };
   }
   interface ThemeOptions {
     logos?: {
-      normal: ImageColorSchemeSwitchType;
-      short?: ImageColorSchemeSwitchType;
+      normal: ImageColourSchemeSwitchType;
+      short?: ImageColourSchemeSwitchType;
     };
   }
 }


### PR DESCRIPTION
ImageColorSchemeSwitch, ImageColorSchemeSwitchType and ImageColorSchemeSwitchProps renamed to ImageColourSchemeSwitch, ImageColourSchemeSwitchType and ImageColourSchemeSwitchProps. User component color prop renamed to colour.
Renamed color to colour in stories.

Closes #78 