### PR TITLE
Only include relevant files in npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@diamondlightsource/sci-react-ui",
   "version": "0.2.1-alpha",
+  "files": [
+    "dist/",
+    "src/",
+    "index.js"
+  ],
   "description": "A theme and component library to make websites at scientific institutions simple to create.",
   "author": "Diamond Light Source",
   "license": "ISC",


### PR DESCRIPTION
Fixes #75 
Added a files section to `package.json` so that only the relevant files are included in the npm package. 
Currently I've included `/src/` but I'm not sure this is necessary? I could remove this.