### PR TITLE
Replacing JsonForms readonly inputs with accessible text.

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -75,6 +75,18 @@ const preview: Preview = {
     },
     backgrounds: { disable: true },
     layout: "fullscreen",
+    options: {
+      storySort: {
+        order: [
+          "Introduction",
+          "Components",
+          "Theme",
+          "Theme/Logos",
+          "Theme/Colours",
+          "Helpers",
+        ],
+      },
+    },
   },
   argTypes: {
     linkComponent: {

--- a/changelog.md
+++ b/changelog.md
@@ -9,12 +9,16 @@ SciReactUI Changelog
 - *Logo* component, to easily add the theme logo to anywhere
 - *ImageColourSchemeSwitch* takes a parameter *interchange* to swap image based on the opposite 
 of the colour scheme switch - for use with alternative background colours.
+- *BaseBar* component is the base for all the bars used in SciReactUI. Can also be used itself.
+- *AppBar* is a bar to show the main title of your App.
+- JsonForms renderers have been added for use with readonly mode in JsonForms.
 
 ### Fixed
 - Themes were not inheriting all details from their parents.
 - Fixed alt text on logos.
 - Fixed Footer was not adhering to Container width. (Can be turned off with containerWidth setting)
 - Fixed bug in Footer Links where alignment was out on first link.
+- Ordering of StoryBook now more intuitive.
 
 
 ### Changed
@@ -23,7 +27,7 @@ of the colour scheme switch - for use with alternative background colours.
   renamed to *ImageColourSchemeSwitch*, ImageColourSchemeSwitchType and ImageColourSchemeSwitchProps respectively 
   - *User* component color prop renamed to colour.
 - RootProps on *Breadcrumbs* has been removed. There props can be passed in directly. 
-e.g. `<B... sx={{color:"red}} />` instead of `<B... rootProps={{sx: { backgroundColor: "blue" } }}/>` 
+e.g. `<Breadcrumbs sx={{color:"red"}} />` instead of `<Breadcrumbs rootProps={{sx: { color: "red" } }}/>` 
 
 
 [v0.2.0] - 2025-06-11

--- a/package.json
+++ b/package.json
@@ -30,6 +30,9 @@
   "peerDependencies": {
     "@emotion/react": "^11.13.3",
     "@emotion/styled": "^11.13.0",
+    "@jsonforms/core": "^3.6.0",
+    "@jsonforms/material-renderers": "^3.6.0",
+    "@jsonforms/react": "^3.6.0",
     "@mui/icons-material": "^6.1.7",
     "@mui/material": "^6.1.7",
     "react": "^18.3.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,15 @@ importers:
       '@emotion/styled':
         specifier: ^11.13.0
         version: 11.14.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1)
+      '@jsonforms/core':
+        specifier: ^3.6.0
+        version: 3.6.0
+      '@jsonforms/material-renderers':
+        specifier: ^3.6.0
+        version: 3.6.0(urt6nrxqlj2unp4w44pnlaf44a)
+      '@jsonforms/react':
+        specifier: ^3.6.0
+        version: 3.6.0(@jsonforms/core@3.6.0)(react@18.3.1)
       '@mui/icons-material':
         specifier: ^6.1.7
         version: 6.3.1(@mui/material@6.3.1(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.18)(react@18.3.1)
@@ -820,6 +829,17 @@ packages:
     peerDependencies:
       storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
 
+  '@date-io/core@3.2.0':
+    resolution: {integrity: sha512-hqwXvY8/YBsT9RwQITG868ZNb1MVFFkF7W1Ecv4P472j/ZWa7EFcgSmxy8PUElNVZfvhdvfv+a8j6NWJqOX5mA==}
+
+  '@date-io/dayjs@3.2.0':
+    resolution: {integrity: sha512-+3LV+3N+cpQbEtmrFo8odg07k02AFY7diHgbi2EKYYANOOCPkDYUjDr2ENiHuYNidTs3tZwzDKckZoVNN4NXxg==}
+    peerDependencies:
+      dayjs: ^1.8.17
+    peerDependenciesMeta:
+      dayjs:
+        optional: true
+
   '@emotion/babel-plugin@11.13.5':
     resolution: {integrity: sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==}
 
@@ -1176,6 +1196,27 @@ packages:
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
 
+  '@jsonforms/core@3.6.0':
+    resolution: {integrity: sha512-Qz7qJPf/yP4ybqknZ500zggIDZRJfcufu+3efp/xNWf05mpXvxN9TdfmA++BdXi5Nr4UAgjos2kFmQpZpQaCDw==}
+
+  '@jsonforms/material-renderers@3.6.0':
+    resolution: {integrity: sha512-23ktHVnDDykOXQP2go312/7yNKiR1f/o0GJ2xNg+LVH6PtCWtzdPxaY6WFKWLt84s1DgEHyCw466XEVrPec5dA==}
+    peerDependencies:
+      '@emotion/react': ^11.4.1
+      '@emotion/styled': ^11.3.0
+      '@jsonforms/core': 3.6.0
+      '@jsonforms/react': 3.6.0
+      '@mui/icons-material': ^5.11.16 || ^6.0.0
+      '@mui/material': ^5.13.0 || ^6.0.0
+      '@mui/x-date-pickers': ^6.0.0 || ^7.0.0
+      react: ^16.12.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@jsonforms/react@3.6.0':
+    resolution: {integrity: sha512-dor7FYltCkNkAM+SVZGtabjpUhGlj0/coAqx7GIZ8h+leET+d1sLEAc8kfxxh6gZBq9C4KAErb0Pj3uHedOs9Q==}
+    peerDependencies:
+      '@jsonforms/core': 3.6.0
+      react: ^16.12.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   '@mdx-js/react@3.1.0':
     resolution: {integrity: sha512-QjHtSaoameoalGnKDT3FoIl4+9RwyTmo9ZJGBdLOks/YOiWHoRDI3PUwEzOE7kEmGcV3AFcp9K6dYu9rEuKLAQ==}
     peerDependencies:
@@ -1272,6 +1313,49 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  '@mui/x-date-pickers@7.29.4':
+    resolution: {integrity: sha512-wJ3tsqk/y6dp+mXGtT9czciAMEO5Zr3IIAHg9x6IL0Eqanqy0N3chbmQQZv3iq0m2qUpQDLvZ4utZBUTJdjNzw==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@emotion/react': ^11.9.0
+      '@emotion/styled': ^11.8.1
+      '@mui/material': ^5.15.14 || ^6.0.0 || ^7.0.0
+      '@mui/system': ^5.15.14 || ^6.0.0 || ^7.0.0
+      date-fns: ^2.25.0 || ^3.2.0 || ^4.0.0
+      date-fns-jalali: ^2.13.0-0 || ^3.2.0-0 || ^4.0.0-0
+      dayjs: ^1.10.7
+      luxon: ^3.0.2
+      moment: ^2.29.4
+      moment-hijri: ^2.1.2 || ^3.0.0
+      moment-jalaali: ^0.7.4 || ^0.8.0 || ^0.9.0 || ^0.10.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/react':
+        optional: true
+      '@emotion/styled':
+        optional: true
+      date-fns:
+        optional: true
+      date-fns-jalali:
+        optional: true
+      dayjs:
+        optional: true
+      luxon:
+        optional: true
+      moment:
+        optional: true
+      moment-hijri:
+        optional: true
+      moment-jalaali:
+        optional: true
+
+  '@mui/x-internals@7.29.0':
+    resolution: {integrity: sha512-+Gk6VTZIFD70XreWvdXBwKd8GZ2FlSCuecQFzm6znwqXg1ZsndavrhG9tkxpxo2fM1Zf7Tk8+HcOO0hCbhTQFA==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -2512,6 +2596,9 @@ packages:
   data-view-byte-offset@1.0.1:
     resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
     engines: {node: '>= 0.4'}
+
+  dayjs@1.10.7:
+    resolution: {integrity: sha512-P6twpd70BcPK34K26uJ1KT3wlhpuOAPoMwJzpsIWUxHZ7wpmbdZL/hQqBDfz7hGurYSa5PhzdhDHtt319hL3ig==}
 
   debug@4.4.0:
     resolution: {integrity: sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==}
@@ -5800,6 +5887,14 @@ snapshots:
       - '@chromatic-com/playwright'
       - react
 
+  '@date-io/core@3.2.0': {}
+
+  '@date-io/dayjs@3.2.0(dayjs@1.10.7)':
+    dependencies:
+      '@date-io/core': 3.2.0
+    optionalDependencies:
+      dayjs: 1.10.7
+
   '@emotion/babel-plugin@11.13.5':
     dependencies:
       '@babel/helper-module-imports': 7.25.9
@@ -6214,6 +6309,33 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
 
+  '@jsonforms/core@3.6.0':
+    dependencies:
+      '@types/json-schema': 7.0.15
+      ajv: 8.17.1
+      ajv-formats: 2.1.1(ajv@8.17.1)
+      lodash: 4.17.21
+
+  '@jsonforms/material-renderers@3.6.0(urt6nrxqlj2unp4w44pnlaf44a)':
+    dependencies:
+      '@date-io/dayjs': 3.2.0(dayjs@1.10.7)
+      '@emotion/react': 11.14.0(@types/react@18.3.18)(react@18.3.1)
+      '@emotion/styled': 11.14.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1)
+      '@jsonforms/core': 3.6.0
+      '@jsonforms/react': 3.6.0(@jsonforms/core@3.6.0)(react@18.3.1)
+      '@mui/icons-material': 6.3.1(@mui/material@6.3.1(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.18)(react@18.3.1)
+      '@mui/material': 6.3.1(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@mui/x-date-pickers': 7.29.4(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1))(@mui/material@6.3.1(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mui/system@6.3.1(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(dayjs@1.10.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      dayjs: 1.10.7
+      lodash: 4.17.21
+      react: 18.3.1
+
+  '@jsonforms/react@3.6.0(@jsonforms/core@3.6.0)(react@18.3.1)':
+    dependencies:
+      '@jsonforms/core': 3.6.0
+      lodash: 4.17.21
+      react: 18.3.1
+
   '@mdx-js/react@3.1.0(@types/react@18.3.18)(react@18.3.1)':
     dependencies:
       '@types/mdx': 2.0.13
@@ -6304,6 +6426,34 @@ snapshots:
       react-is: 19.0.0
     optionalDependencies:
       '@types/react': 18.3.18
+
+  '@mui/x-date-pickers@7.29.4(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1))(@mui/material@6.3.1(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mui/system@6.3.1(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(dayjs@1.10.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.26.0
+      '@mui/material': 6.3.1(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@mui/system': 6.3.1(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1)
+      '@mui/utils': 6.3.1(@types/react@18.3.18)(react@18.3.1)
+      '@mui/x-internals': 7.29.0(@types/react@18.3.18)(react@18.3.1)
+      '@types/react-transition-group': 4.4.12(@types/react@18.3.18)
+      clsx: 2.1.1
+      prop-types: 15.8.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-transition-group: 4.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+    optionalDependencies:
+      '@emotion/react': 11.14.0(@types/react@18.3.18)(react@18.3.1)
+      '@emotion/styled': 11.14.0(@emotion/react@11.14.0(@types/react@18.3.18)(react@18.3.1))(@types/react@18.3.18)(react@18.3.1)
+      dayjs: 1.10.7
+    transitivePeerDependencies:
+      - '@types/react'
+
+  '@mui/x-internals@7.29.0(@types/react@18.3.18)(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.26.0
+      '@mui/utils': 6.3.1(@types/react@18.3.18)(react@18.3.1)
+      react: 18.3.1
+    transitivePeerDependencies:
+      - '@types/react'
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -7752,6 +7902,8 @@ snapshots:
       call-bound: 1.0.3
       es-errors: 1.3.0
       is-data-view: 1.0.2
+
+  dayjs@1.10.7: {}
 
   debug@4.4.0:
     dependencies:

--- a/src/components/controls/AppTitlebar.stories.tsx
+++ b/src/components/controls/AppTitlebar.stories.tsx
@@ -2,7 +2,7 @@ import { Meta, StoryObj } from "@storybook/react";
 import { AppTitle, AppTitlebar } from "./AppTitlebar";
 
 const meta: Meta<typeof AppTitlebar> = {
-  title: "SciReactUI/Control/AppTitlebar",
+  title: "Components/Controls/AppTitlebar",
   component: AppTitlebar,
   tags: ["autodocs"],
   parameters: {

--- a/src/components/controls/Bar.stories.tsx
+++ b/src/components/controls/Bar.stories.tsx
@@ -2,7 +2,7 @@ import { Meta, StoryObj } from "@storybook/react";
 import { Bar, BarProps } from "./Bar";
 
 const meta: Meta<typeof Bar> = {
-  title: "SciReactUI/Control/Bar",
+  title: "Components/Controls/Bar",
   component: Bar,
   tags: ["autodocs"],
 };

--- a/src/components/controls/ColourSchemeButton.stories.tsx
+++ b/src/components/controls/ColourSchemeButton.stories.tsx
@@ -2,7 +2,7 @@ import { Meta, StoryObj } from "@storybook/react";
 import { ColourSchemeButton } from "./ColourSchemeButton";
 
 const meta: Meta<typeof ColourSchemeButton> = {
-  title: "SciReactUI/Control/ColourSchemeButton",
+  title: "Components/Controls/ColourSchemeButton",
   component: ColourSchemeButton,
   tags: ["autodocs"],
   parameters: {

--- a/src/components/controls/ImageColourSchemeSwitch.stories.tsx
+++ b/src/components/controls/ImageColourSchemeSwitch.stories.tsx
@@ -5,7 +5,7 @@ import imageDark from "../../public/generic/logo-dark.svg";
 import imageLight from "../../public/generic/logo-light.svg";
 
 const meta: Meta<typeof ImageColourSchemeSwitch> = {
-  title: "SciReactUI/Control/ImageColourSchemeSwitch",
+  title: "Components/Controls/ImageColourSchemeSwitch",
   component: ImageColourSchemeSwitch,
   tags: ["autodocs"],
 };

--- a/src/components/controls/Logo.stories.tsx
+++ b/src/components/controls/Logo.stories.tsx
@@ -2,7 +2,7 @@ import { Meta, StoryObj } from "@storybook/react";
 import { Logo } from "./Logo";
 
 const meta: Meta<typeof Logo> = {
-  title: "SciReactUI/Control/Logo",
+  title: "Components/Controls/Logo",
   component: Logo,
   tags: ["autodocs"],
   parameters: {

--- a/src/components/controls/ScrollableImages.stories.tsx
+++ b/src/components/controls/ScrollableImages.stories.tsx
@@ -9,7 +9,7 @@ import shanghai from "../../public/images/shanghai.jpg";
 import { useEffect, useState } from "react";
 
 const meta: Meta<typeof ScrollableImages> = {
-  title: "SciReactUI/Control/ScrollableImages",
+  title: "Components/Controls/ScrollableImages",
   component: ScrollableImages,
   tags: ["autodocs"],
 };

--- a/src/components/controls/User.stories.tsx
+++ b/src/components/controls/User.stories.tsx
@@ -4,7 +4,7 @@ import { User } from "./User";
 import { Avatar, Link, MenuItem } from "@mui/material";
 
 const meta: Meta<typeof User> = {
-  title: "SciReactUI/Control/User",
+  title: "Components/Controls/User",
   component: User,
   tags: ["autodocs"],
 };

--- a/src/components/controls/VisitInput.stories.tsx
+++ b/src/components/controls/VisitInput.stories.tsx
@@ -3,7 +3,7 @@ import { Visit } from "../../utils/diamond";
 import { VisitInput } from "./VisitInput";
 
 const meta: Meta<typeof VisitInput> = {
-  title: "SciReactUI/Control/VisitInput",
+  title: "Components/Controls/VisitInput",
   component: VisitInput,
   tags: ["autodocs"],
 };

--- a/src/components/helpers/jsonforms/components/DataBox.test.tsx
+++ b/src/components/helpers/jsonforms/components/DataBox.test.tsx
@@ -1,39 +1,40 @@
-import { describe, expect, test } from "vitest";
+import "@testing-library/jest-dom";
 import { render, screen } from "@testing-library/react";
 
-import {DataBox} from "./DataBox";
+import { DataBox } from "./DataBox";
 
 const props = {
-	label: "A Label",
-	data: "Data 1234",
+  label: "A Label",
+  data: "Data 1234",
 };
 
 describe("DataBox", () => {
-	test("Should render data and label", () => {
-		render(<DataBox {...props} />);
-		
-		expect(screen.getByText(props.label)).toBeInTheDocument();
-		expect(screen.getByText(props.data)).toBeInTheDocument();
-	});
-	
-	test("Should render '-' with empty data", () => {
-		render(<DataBox {...props} data="" />);
-		
-		expect(screen.getByText(props.label)).toBeInTheDocument();
-		expect(screen.getByText("-")).toBeInTheDocument();
-	});
-	
-	test("Should render '-' with null data", () => {
-		render(<DataBox {...props} data={null} />);
-		
-		expect(screen.getByText(props.label)).toBeInTheDocument();
-		expect(screen.getByText("-")).toBeInTheDocument();
-	});
-	
-	test("Should render '-' with undefined data", () => {
-		render(<DataBox {...props} />);
-		
-		expect(screen.getByText(props.label)).toBeInTheDocument();
-		expect(screen.getByText("-")).toBeInTheDocument();
-	});
+  test("Should render data and label", () => {
+    const { container } = render(<DataBox {...props} />);
+
+    expect(screen.getByText(props.label)).toBeInTheDocument();
+    expect(screen.getByText(props.data)).toBeInTheDocument();
+    expect(container.querySelector("dd span.empty")).not.toBeInTheDocument();
+  });
+
+  test("Should render '-' with empty data", () => {
+    const { container } = render(<DataBox {...props} data="" />);
+
+    expect(screen.getByText(props.label)).toBeInTheDocument();
+    expect(container.querySelector("dd span.empty")).toBeInTheDocument();
+  });
+
+  test("Should render '-' with null data", () => {
+    const { container } = render(<DataBox {...props} data={null} />);
+
+    expect(screen.getByText(props.label)).toBeInTheDocument();
+    expect(container.querySelector("dd span.empty")).toBeInTheDocument();
+  });
+
+  test("Should render '-' with undefined data", () => {
+    const { container } = render(<DataBox label={props.label} />);
+
+    expect(screen.getByText(props.label)).toBeInTheDocument();
+    expect(container.querySelector("dd span.empty")).toBeInTheDocument();
+  });
 });

--- a/src/components/helpers/jsonforms/components/DataBox.test.tsx
+++ b/src/components/helpers/jsonforms/components/DataBox.test.tsx
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import {DataBox} from "./DataBox";
+
+const props = {
+	label: "A Label",
+	data: "Data 1234",
+};
+
+describe("DataBox", () => {
+	test("Should render data and label", () => {
+		render(<DataBox {...props} />);
+		
+		expect(screen.getByText(props.label)).toBeInTheDocument();
+		expect(screen.getByText(props.data)).toBeInTheDocument();
+	});
+	
+	test("Should render '-' with empty data", () => {
+		render(<DataBox {...props} data="" />);
+		
+		expect(screen.getByText(props.label)).toBeInTheDocument();
+		expect(screen.getByText("-")).toBeInTheDocument();
+	});
+	
+	test("Should render '-' with null data", () => {
+		render(<DataBox {...props} data={null} />);
+		
+		expect(screen.getByText(props.label)).toBeInTheDocument();
+		expect(screen.getByText("-")).toBeInTheDocument();
+	});
+	
+	test("Should render '-' with undefined data", () => {
+		render(<DataBox {...props} />);
+		
+		expect(screen.getByText(props.label)).toBeInTheDocument();
+		expect(screen.getByText("-")).toBeInTheDocument();
+	});
+});

--- a/src/components/helpers/jsonforms/components/DataBox.tsx
+++ b/src/components/helpers/jsonforms/components/DataBox.tsx
@@ -1,27 +1,45 @@
-import {Box, Stack, Typography} from "@mui/material";
+import { Box, Stack, Typography } from "@mui/material";
 
 interface DataBoxProps {
-	label: string,
-	data: string | null | undefined,
+  label: string;
+  data?: string | null;
 }
 
-const DataBox = ({label, data}: DataBoxProps) => {
-	return (
-		<Box className="data-box" sx={{ paddingBottom: "10px" }}>
-			<Stack direction="column">
-				<Typography
-					component="span"
-					className="data-box-label"
-					sx={{ fontWeight: "bold", fontSize: "smaller", color: "red" }}
-				>
-					{label}
-				</Typography>
-				<Typography className="data-box-data" component="span">
-					{data ? data : "-"}
-				</Typography>
-			</Stack>
-		</Box>
-	)
-}
+export const DataOrEmpty = ({ data }: { data?: string | null }) =>
+  data ? (
+    data
+  ) : (
+    <Typography
+      component="span"
+      className="empty"
+      sx={{ "&:before": { content: '"-"' } }}
+    />
+  );
+
+const DataBox = ({ label, data }: DataBoxProps) => (
+  <Box className="data-box">
+    <Stack direction="column">
+      <Box className="data-box-label">
+        <Typography
+          component="dt"
+          variant="h6"
+          sx={{
+            fontWeight: "bold",
+            textTransform: "capitalize",
+            fontSize: "smaller",
+          }}
+        >
+          {label}
+        </Typography>
+      </Box>
+
+      <Box className="data-box-data">
+        <Typography component="dd">
+          <DataOrEmpty data={data} />
+        </Typography>
+      </Box>
+    </Stack>
+  </Box>
+);
 
 export { DataBox };

--- a/src/components/helpers/jsonforms/components/DataBox.tsx
+++ b/src/components/helpers/jsonforms/components/DataBox.tsx
@@ -1,0 +1,27 @@
+import {Box, Stack, Typography} from "@mui/material";
+
+interface DataBoxProps {
+	label: string,
+	data: string | null | undefined,
+}
+
+const DataBox = ({label, data}: DataBoxProps) => {
+	return (
+		<Box className="data-box" sx={{ paddingBottom: "10px" }}>
+			<Stack direction="column">
+				<Typography
+					component="span"
+					className="data-box-label"
+					sx={{ fontWeight: "bold", fontSize: "smaller", color: "red" }}
+				>
+					{label}
+				</Typography>
+				<Typography className="data-box-data" component="span">
+					{data ? data : "-"}
+				</Typography>
+			</Stack>
+		</Box>
+	)
+}
+
+export { DataBox };

--- a/src/components/helpers/jsonforms/components/DataCell.test.tsx
+++ b/src/components/helpers/jsonforms/components/DataCell.test.tsx
@@ -1,30 +1,31 @@
-import { describe, expect, test } from "vitest";
+import "@testing-library/jest-dom";
 import { render, screen } from "@testing-library/react";
 
-import {DataCell} from "./DataCell";
+import { DataCell } from "./DataCell";
 
 const props = {
-	data: "Data 1234",
+  data: "Data 1234",
 };
 
 describe("DataCell", () => {
-	test("Should render data and label", () => {
-		render(<DataCell {...props} />);
-		expect(screen.getByText(props.data)).toBeInTheDocument();
-	});
-	
-	test("Should render '-' with empty data", () => {
-		render(<DataCell {...props} data="" />);
-		expect(screen.getByText("-")).toBeInTheDocument();
-	});
-	
-	test("Should render '-' with null data", () => {
-		render(<DataCell {...props} data={null} />);
-		expect(screen.getByText("-")).toBeInTheDocument();
-	});
-	
-	test("Should render '-' with undefined data", () => {
-		render(<DataCell {...props} />);
-		expect(screen.getByText("-")).toBeInTheDocument();
-	});
+  test("Should render data and label", () => {
+    const { container } = render(<DataCell {...props} />);
+    expect(screen.getByText(props.data)).toBeInTheDocument();
+    expect(container.querySelector("span.empty")).not.toBeInTheDocument();
+  });
+
+  test("Should render '-' with empty data", () => {
+    const { container } = render(<DataCell data="" />);
+    expect(container.querySelector("span.empty")).toBeInTheDocument();
+  });
+
+  test("Should render '-' with null data", () => {
+    const { container } = render(<DataCell data={null} />);
+    expect(container.querySelector("span.empty")).toBeInTheDocument();
+  });
+
+  test("Should render '-' with undefined data", () => {
+    const { container } = render(<DataCell />);
+    expect(container.querySelector("span.empty")).toBeInTheDocument();
+  });
 });

--- a/src/components/helpers/jsonforms/components/DataCell.test.tsx
+++ b/src/components/helpers/jsonforms/components/DataCell.test.tsx
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import {DataCell} from "./DataCell";
+
+const props = {
+	data: "Data 1234",
+};
+
+describe("DataCell", () => {
+	test("Should render data and label", () => {
+		render(<DataCell {...props} />);
+		expect(screen.getByText(props.data)).toBeInTheDocument();
+	});
+	
+	test("Should render '-' with empty data", () => {
+		render(<DataCell {...props} data="" />);
+		expect(screen.getByText("-")).toBeInTheDocument();
+	});
+	
+	test("Should render '-' with null data", () => {
+		render(<DataCell {...props} data={null} />);
+		expect(screen.getByText("-")).toBeInTheDocument();
+	});
+	
+	test("Should render '-' with undefined data", () => {
+		render(<DataCell {...props} />);
+		expect(screen.getByText("-")).toBeInTheDocument();
+	});
+});

--- a/src/components/helpers/jsonforms/components/DataCell.tsx
+++ b/src/components/helpers/jsonforms/components/DataCell.tsx
@@ -1,0 +1,17 @@
+import {Box, Typography} from "@mui/material";
+
+interface DataBoxProps {
+	data: string | null | undefined,
+}
+
+const DataCell = ({data}: DataBoxProps) => {
+	return (
+		<Box>
+			<Typography component="span" sx={{ fontSize: "smaller" }}>
+				{data ? data : "-"}
+			</Typography>
+		</Box>
+	)
+}
+
+export { DataCell };

--- a/src/components/helpers/jsonforms/components/DataCell.tsx
+++ b/src/components/helpers/jsonforms/components/DataCell.tsx
@@ -1,17 +1,16 @@
-import {Box, Typography} from "@mui/material";
+import { Box, Typography } from "@mui/material";
+import { DataOrEmpty } from "./DataBox";
 
-interface DataBoxProps {
-	data: string | null | undefined,
+interface DataCellProps {
+  data?: string | null;
 }
 
-const DataCell = ({data}: DataBoxProps) => {
-	return (
-		<Box>
-			<Typography component="span" sx={{ fontSize: "smaller" }}>
-				{data ? data : "-"}
-			</Typography>
-		</Box>
-	)
-}
+const DataCell = ({ data }: DataCellProps) => (
+  <Box>
+    <Typography component="span" sx={{ fontSize: "smaller" }}>
+      <DataOrEmpty data={data} />
+    </Typography>
+  </Box>
+);
 
 export { DataCell };

--- a/src/components/helpers/jsonforms/controls/CellTextControl.tsx
+++ b/src/components/helpers/jsonforms/controls/CellTextControl.tsx
@@ -1,20 +1,26 @@
 import { withJsonFormsCellProps } from "@jsonforms/react";
-import {and, CellProps, or, rankWith, schemaTypeIs, uiTypeIs} from "@jsonforms/core";
+import {
+  and,
+  CellProps,
+  or,
+  rankWith,
+  schemaTypeIs,
+  uiTypeIs,
+} from "@jsonforms/core";
 
-import {DataCell} from "../components/DataCell";
+import { DataCell } from "../components/DataCell";
 
 const CellTextControlTester = rankWith(
-	110, and(
-		uiTypeIs("Control"),
-		or(schemaTypeIs("integer"), schemaTypeIs("number"), schemaTypeIs("string"))
-	)
+  10,
+  and(
+    uiTypeIs("Control"),
+    or(schemaTypeIs("integer"), schemaTypeIs("number"), schemaTypeIs("string")),
+  ),
 );
 
 const CellTextControlComponent = ({ data }: CellProps) => (
   <DataCell data={data} />
-)
-
-const CellTextControl = withJsonFormsCellProps(
-  CellTextControlComponent
 );
+
+const CellTextControl = withJsonFormsCellProps(CellTextControlComponent);
 export { CellTextControl, CellTextControlTester };

--- a/src/components/helpers/jsonforms/controls/CellTextControl.tsx
+++ b/src/components/helpers/jsonforms/controls/CellTextControl.tsx
@@ -1,0 +1,20 @@
+import { withJsonFormsCellProps } from "@jsonforms/react";
+import {and, CellProps, or, rankWith, schemaTypeIs, uiTypeIs} from "@jsonforms/core";
+
+import {DataCell} from "../components/DataCell";
+
+const CellTextControlTester = rankWith(
+	110, and(
+		uiTypeIs("Control"),
+		or(schemaTypeIs("integer"), schemaTypeIs("number"), schemaTypeIs("string"))
+	)
+);
+
+const CellTextControlComponent = ({ data }: CellProps) => (
+  <DataCell data={data} />
+)
+
+const CellTextControl = withJsonFormsCellProps(
+  CellTextControlComponent
+);
+export { CellTextControl, CellTextControlTester };

--- a/src/components/helpers/jsonforms/controls/CellTextDateTimeControl.tsx
+++ b/src/components/helpers/jsonforms/controls/CellTextDateTimeControl.tsx
@@ -1,20 +1,27 @@
 import { withJsonFormsCellProps } from "@jsonforms/react";
-import {and, CellProps, isStringControl, rankWith, schemaMatches} from "@jsonforms/core";
+import {
+  and,
+  CellProps,
+  isStringControl,
+  rankWith,
+  schemaMatches,
+} from "@jsonforms/core";
 
-import {DataCell} from "../components/DataCell";
+import { DataCell } from "../components/DataCell";
 
 const CellTextDateTimeControlTester = rankWith(
-	120, and(
-		isStringControl,
-		schemaMatches((schema) => schema.format === "date-time")
-	)
+  15,
+  and(
+    isStringControl,
+    schemaMatches((schema) => schema.format === "date-time"),
+  ),
 );
 
 const CellTextDateTimeControlComponent = ({ data }: CellProps) => (
-  <DataCell data={(data) ? new Date(data).toLocaleString("en-GB") : undefined} />
-)
+  <DataCell data={data ? new Date(data).toLocaleString("en-GB") : undefined} />
+);
 
 const CellTextDateTimeControl = withJsonFormsCellProps(
-	CellTextDateTimeControlComponent
+  CellTextDateTimeControlComponent,
 );
 export { CellTextDateTimeControl, CellTextDateTimeControlTester };

--- a/src/components/helpers/jsonforms/controls/CellTextDateTimeControl.tsx
+++ b/src/components/helpers/jsonforms/controls/CellTextDateTimeControl.tsx
@@ -1,0 +1,20 @@
+import { withJsonFormsCellProps } from "@jsonforms/react";
+import {and, CellProps, isStringControl, rankWith, schemaMatches} from "@jsonforms/core";
+
+import {DataCell} from "../components/DataCell";
+
+const CellTextDateTimeControlTester = rankWith(
+	120, and(
+		isStringControl,
+		schemaMatches((schema) => schema.format === "date-time")
+	)
+);
+
+const CellTextDateTimeControlComponent = ({ data }: CellProps) => (
+  <DataCell data={(data) ? new Date(data).toLocaleString("en-GB") : undefined} />
+)
+
+const CellTextDateTimeControl = withJsonFormsCellProps(
+	CellTextDateTimeControlComponent
+);
+export { CellTextDateTimeControl, CellTextDateTimeControlTester };

--- a/src/components/helpers/jsonforms/controls/TextControl.tsx
+++ b/src/components/helpers/jsonforms/controls/TextControl.tsx
@@ -1,0 +1,18 @@
+import { withJsonFormsControlProps } from "@jsonforms/react";
+
+import {and, ControlProps, or, rankWith, schemaTypeIs, uiTypeIs} from "@jsonforms/core";
+import {DataBox} from "../components/DataBox";
+
+const TextControlTester = rankWith(
+  10, and(
+    uiTypeIs("Control"),
+    or(schemaTypeIs("integer"), schemaTypeIs("number"), schemaTypeIs("string"))
+  )
+);
+
+const TextControlComponent = ({ data, label }: ControlProps) => (
+  <DataBox label={label} data={data} />
+);
+
+const TextControl = withJsonFormsControlProps(TextControlComponent);
+export { TextControl, TextControlTester };

--- a/src/components/helpers/jsonforms/controls/TextControl.tsx
+++ b/src/components/helpers/jsonforms/controls/TextControl.tsx
@@ -1,13 +1,21 @@
 import { withJsonFormsControlProps } from "@jsonforms/react";
 
-import {and, ControlProps, or, rankWith, schemaTypeIs, uiTypeIs} from "@jsonforms/core";
-import {DataBox} from "../components/DataBox";
+import {
+  and,
+  ControlProps,
+  or,
+  rankWith,
+  schemaTypeIs,
+  uiTypeIs,
+} from "@jsonforms/core";
+import { DataBox } from "../components/DataBox";
 
 const TextControlTester = rankWith(
-  10, and(
+  10,
+  and(
     uiTypeIs("Control"),
-    or(schemaTypeIs("integer"), schemaTypeIs("number"), schemaTypeIs("string"))
-  )
+    or(schemaTypeIs("integer"), schemaTypeIs("number"), schemaTypeIs("string")),
+  ),
 );
 
 const TextControlComponent = ({ data, label }: ControlProps) => (

--- a/src/components/helpers/jsonforms/controls/TextDateTimeControl.tsx
+++ b/src/components/helpers/jsonforms/controls/TextDateTimeControl.tsx
@@ -1,0 +1,20 @@
+import { withJsonFormsControlProps } from "@jsonforms/react";
+import { rankWith, isStringControl, and, schemaMatches, ControlProps } from "@jsonforms/core";
+
+import {DataBox} from "../components/DataBox";
+
+const TextDateTimeControlTester = rankWith(
+  20, and(
+    isStringControl,
+    schemaMatches((schema) => schema.format === "date-time")
+  )
+);
+
+const TextDateTimeControlComponent = ({ data, label }: ControlProps) => (
+  <DataBox label={label} data={(data) ? new Date(data).toLocaleString("en-GB") : undefined} />
+);
+
+const TextDateTimeControl = withJsonFormsControlProps(
+  TextDateTimeControlComponent
+);
+export { TextDateTimeControl, TextDateTimeControlTester };

--- a/src/components/helpers/jsonforms/controls/TextDateTimeControl.tsx
+++ b/src/components/helpers/jsonforms/controls/TextDateTimeControl.tsx
@@ -1,20 +1,30 @@
 import { withJsonFormsControlProps } from "@jsonforms/react";
-import { rankWith, isStringControl, and, schemaMatches, ControlProps } from "@jsonforms/core";
+import {
+  rankWith,
+  isStringControl,
+  and,
+  schemaMatches,
+  ControlProps,
+} from "@jsonforms/core";
 
-import {DataBox} from "../components/DataBox";
+import { DataBox } from "../components/DataBox";
 
 const TextDateTimeControlTester = rankWith(
-  20, and(
+  15,
+  and(
     isStringControl,
-    schemaMatches((schema) => schema.format === "date-time")
-  )
+    schemaMatches((schema) => schema.format === "date-time"),
+  ),
 );
 
 const TextDateTimeControlComponent = ({ data, label }: ControlProps) => (
-  <DataBox label={label} data={(data) ? new Date(data).toLocaleString("en-GB") : undefined} />
+  <DataBox
+    label={label}
+    data={data ? new Date(data).toLocaleString("en-GB") : undefined}
+  />
 );
 
 const TextDateTimeControl = withJsonFormsControlProps(
-  TextDateTimeControlComponent
+  TextDateTimeControlComponent,
 );
 export { TextDateTimeControl, TextDateTimeControlTester };

--- a/src/components/helpers/jsonforms/index.ts
+++ b/src/components/helpers/jsonforms/index.ts
@@ -1,15 +1,28 @@
-import {	TextControl,	TextControlTester} from "./controls/TextControl";
-import {	TextDateTimeControl,	TextDateTimeControlTester} from "./controls/TextDateTimeControl";
+import { TextControl, TextControlTester } from "./controls/TextControl";
+import {
+  TextDateTimeControl,
+  TextDateTimeControlTester,
+} from "./controls/TextDateTimeControl";
 
-import { CellTextControl,	CellTextControlTester } from "./controls/CellTextControl";
-import {	CellTextDateTimeControl, CellTextDateTimeControlTester} from "./controls/CellTextDateTimeControl";
+import {
+  CellTextControl,
+  CellTextControlTester,
+} from "./controls/CellTextControl";
+import {
+  CellTextDateTimeControl,
+  CellTextDateTimeControlTester,
+} from "./controls/CellTextDateTimeControl";
 
+const rendererControls = [
+  { renderer: TextControl, tester: TextControlTester },
+  { renderer: TextDateTimeControl, tester: TextDateTimeControlTester },
+];
+const cellControls = [
+  { cell: CellTextControl, tester: CellTextControlTester },
+  { cell: CellTextDateTimeControl, tester: CellTextDateTimeControlTester },
+];
 
-export const rendererControls = [
-	{ renderer: TextControl, tester: TextControlTester },
-	{ renderer: TextDateTimeControl, tester: TextDateTimeControlTester },
-]
-export const cellControls = [
-	{ cell: CellTextControl, tester: CellTextControlTester },
-	{ cell: CellTextDateTimeControl, tester: CellTextDateTimeControlTester },
-]
+export const JsonFormsControls = {
+  rendererControls,
+  cellControls,
+};

--- a/src/components/helpers/jsonforms/index.ts
+++ b/src/components/helpers/jsonforms/index.ts
@@ -1,0 +1,15 @@
+import {	TextControl,	TextControlTester} from "./controls/TextControl";
+import {	TextDateTimeControl,	TextDateTimeControlTester} from "./controls/TextDateTimeControl";
+
+import { CellTextControl,	CellTextControlTester } from "./controls/CellTextControl";
+import {	CellTextDateTimeControl, CellTextDateTimeControlTester} from "./controls/CellTextDateTimeControl";
+
+
+export const rendererControls = [
+	{ renderer: TextControl, tester: TextControlTester },
+	{ renderer: TextDateTimeControl, tester: TextDateTimeControlTester },
+]
+export const cellControls = [
+	{ cell: CellTextControl, tester: CellTextControlTester },
+	{ cell: CellTextDateTimeControl, tester: CellTextDateTimeControlTester },
+]

--- a/src/components/navigation/Breadcrumbs.stories.tsx
+++ b/src/components/navigation/Breadcrumbs.stories.tsx
@@ -3,7 +3,7 @@ import { Breadcrumbs } from "./Breadcrumbs";
 import { MockLink } from "../../utils/MockLink";
 
 const meta: Meta<typeof Breadcrumbs> = {
-  title: "SciReactUI/Navigation/Breadcrumbs",
+  title: "Components/Navigation/Breadcrumbs",
   component: Breadcrumbs,
   tags: ["autodocs"],
 };

--- a/src/components/navigation/Footer.stories.tsx
+++ b/src/components/navigation/Footer.stories.tsx
@@ -3,7 +3,7 @@ import { Footer, FooterLink, FooterLinks } from "./Footer";
 import { MockLink } from "../../utils/MockLink";
 
 const meta: Meta<typeof Footer> = {
-  title: "SciReactUI/Navigation/Footer",
+  title: "Components/Navigation/Footer",
   component: Footer,
   decorators: [(Story) => <Story />],
   tags: ["autodocs"],

--- a/src/components/navigation/Navbar.stories.tsx
+++ b/src/components/navigation/Navbar.stories.tsx
@@ -10,7 +10,7 @@ import { MockLink } from "../../utils/MockLink";
 import { Logo } from "../controls/Logo";
 
 const meta: Meta<typeof Navbar> = {
-  title: "SciReactUI/Navigation/Navbar",
+  title: "Components/Navigation/Navbar",
   component: Navbar,
   tags: ["autodocs"],
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
-// components
 // components/navigation
 export * from "./components/navigation/Breadcrumbs";
 export * from "./components/navigation/Footer";
@@ -12,6 +11,9 @@ export * from "./components/controls/Logo";
 export * from "./components/controls/User";
 export * from "./components/controls/ScrollableImages";
 export * from "./components/controls/VisitInput";
+
+// components/helpers/jsonForms
+export * from "./components/helpers/jsonforms";
 
 // themes
 export * from "./themes/BaseTheme";

--- a/src/storybook/Introduction.mdx
+++ b/src/storybook/Introduction.mdx
@@ -5,13 +5,14 @@ import { Meta } from "@storybook/blocks";
 
 <div className="sb-container">
     <div className='sb-section-title'>
-        # Scientific React UI v{packageJson.version}
+        # Scientific React UI - v{packageJson.version}
 
         ## Introduction
 
-        SciReactUI is a collection of useful scientific focused components, utilizing Material UI, to make your React based websites look great.
+        SciReactUI is a collection of useful scientific focused components which utilizing Material UI
+        to make your React based websites look great.
 
-        This storybook displays the components in @diamondlightsource/sci-react-ui:<strong>{packageJson.version}</strong>.
+        Check out the list of components on the left. To use them, follow the instructions below.
     </div>
 </div>
 
@@ -19,25 +20,33 @@ import { Meta } from "@storybook/blocks";
     <div className='sb-section-title'>
         ## Usage
 
-        ### Add Theme
+        ### First, Install the Package.
 
-        First select a theme: `GenericTheme` or `DiamondTheme` are available to use
-        (you can also create your own, see following section):
+        In your React App, add the latest SciReactUI version:
+
+        ```shell
+        pnpm add @diamondlightsource/sci-react-ui
+        ```
+
+        ### Next, Add a ThemeProvider
+
+        Select a theme, either `GenericTheme` or `DiamondTheme` (Or you can create your own, see below), and add
+        it to the App via the ThemeProvider:
 
         ```tsx filename="main.tsx"
         import {
             ThemeProvider,
-            DiamondTheme
+            GenericTheme
         } from "@diamondlightsource/sci-react-ui";
 
         root.render(
-          <ThemeProvider theme={DiamondTheme}>
+          <ThemeProvider theme={GenericTheme}>
             <App />
           </ThemeProvider>
         )
         ```
 
-        ### Create an App
+        ### Finally, Add the Components
 
         Then create something, for instance, you may want a Navigation Bar at the top of your website:
 
@@ -65,6 +74,42 @@ import { Meta } from "@storybook/blocks";
         export default App;
         ```
 
+        Typically, a complete app page would combine many components, for example:
+
+        ```tsx filename="App.tsx"
+
+        function App() {
+            return <>
+                <Navbar
+                    logo="theme"
+                    leftSlot={
+                        <NavLinks>
+                            <NavLink href="#link">Link</NavLink>
+                        </NavLinks>
+                    }
+                    rightSlot={<>
+                        <User
+                            onLogin={}
+                            onLogout={}
+                        />
+                        <ColourSchemeButton />
+                    </>}
+                />
+
+                <Container>
+                    <Typography>Main Content here.</Typography>
+                </Container>
+
+                <Footer logo="theme">
+                    <FooterLinks>
+                        <FooterLink href="#link">Link</FooterLink>
+                    </FooterLinks>
+                    <p>From SciReactUI</p>
+                </Footer>
+
+            </>
+        }
+        ```
     </div>
 </div>
 

--- a/src/storybook/helpers/JsonForms.mdx
+++ b/src/storybook/helpers/JsonForms.mdx
@@ -1,0 +1,64 @@
+import { Meta } from '@storybook/blocks';
+import {Box, Input, TextField, Typography} from "@mui/material";
+
+<Meta title="Helpers/JsonForms" />
+
+<div className="sb-container">
+	<div className='sb-section-title'>
+		# JsonForms
+
+        JsonForms can be used to automatically generate forms from a JSON file.
+        See <a href="https://jsonforms.io">https://jsonforms.io</a> for more information. If you aren't using JsonForms
+        this section will not be useful.
+
+        These helpers are to be used in "readonly" version of the forms and exist to replace the
+        messy, anti-accessibility problems of the default "disabled" inputs - in particularly, screen readers will
+        skip over disabled inputs. (In JsonForms, "readonly" mode, *disables* all inputs)
+
+        Currently, only the text type inputs are replaced with normal text boxes.
+
+        From this:
+
+        <TextField label="A Label" value="My Value" disabled />
+
+        to this (dependent on your choice of styling):
+
+        <Box style={{width: "100px", border: "1px solid #000000bb", padding: "5px"}}>
+            <Typography component="dt" style={{fontSize:"smaller", fontWeight:"bold"}}>A Label</Typography>
+            <Typography component="dl">My Value</Typography>
+        </Box>
+
+        In react you can use them as follows. Remember to also include the original JsonForm renderers too:
+        ```type=jsx
+        import { materialRenderers, materialCells } from "@jsonforms/material-renderers";
+        import { JsonFormsControls } from "@diamondlightsource/sci-react-ui";
+
+        <JsonForms
+            schema={schema}
+            uischema={uischema}
+            data={data}
+            renderers={[
+                ...materialRenderers,
+                ...JsonFormsControls.rendererControls
+            ]}
+            cells={[
+                ...materialCells,
+                ...JsonFormsControls.cellControls
+            ]}
+            readonly={true}
+        />
+        ```
+
+        You can also add your own renderers, make sure they have a higher rank than SciReactUI ones which are currently
+        set at 10, and 15
+
+        To style them, use these classes:
+        .data-box {}
+        .data-box data-box-title {}
+        .data-box data-box-data {}
+        .data-cell {}
+        .data-cell span {}
+
+    </div>
+
+</div>


### PR DESCRIPTION
This replaces the default readonly text inputs in JsonForms. There are two base controls, DataBox and DataCell are reused in all renderers and cells.

I've added a description of how to use them too StoryBook, but the default StoryBook layout was confusing, so I've changed the ordering, and renamed the group "SciReactUI" to "Components" which affected several files in a small way.

I also tweaked the StoryBook Introduction and updated the Changelog file.