### PR TITLE
Remove use of first:child

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,7 +11,7 @@ SciReactUI Changelog
 -  
 
 ### Changed
-- 
+- Remove first-child css selector as it causes problems with server-side rendering.
 
 [v0.3.0] - 2025-09-04
 ---------------------

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "lint:fix": "eslint --fix .",
     "lint:tsc": "pnpm tsc --noEmit",
     "rollup": "rollup --config rollup.config.mjs",
-    "storybook": "storybook dev -p 6006",
+    "storybook": "storybook dev -p 6006 --disable-telemetry",
     "storybook:build": "storybook build -o storybook-static",
     "storybook:publish": "gh-pages -b storybook/publish -d storybook-static"
   },

--- a/src/components/controls/ColourSchemeButton.tsx
+++ b/src/components/controls/ColourSchemeButton.tsx
@@ -1,6 +1,8 @@
 import { useColorScheme, useTheme } from "@mui/material";
 import { IconButton, IconButtonProps } from "@mui/material";
-import { LightMode, Bedtime } from "@mui/icons-material";
+
+import LightMode from "@mui/icons-material/LightMode";
+import Bedtime from "@mui/icons-material/Bedtime";
 
 import { ColourSchemes } from "../../utils/globals";
 

--- a/src/components/navigation/Footer.tsx
+++ b/src/components/navigation/Footer.tsx
@@ -70,15 +70,12 @@ const FooterLink = ({
         },
         textDecoration: "none",
         color: theme.palette.primary.contrastText,
-        marginLeft: "1.5rem",
+        marginRight: "1.5rem",
         marginBottom: "4px",
         paddingBottom: "4px",
         lineHeight: 1,
         cursor: "pointer",
         borderBottom: "solid transparent 4px",
-        "&:first-child": {
-          marginLeft: 0,
-        },
       }}
       {...props}
     >


### PR DESCRIPTION
Remove use of first:child as it can cause errors if used in server-side rendering.

More info in
https://github.com/DiamondLightSource/sci-react-ui/issues/102

first-child is not needed here, the margin is moved to the end.