### PR TITLE
Resolve NavBar and Footer colour contrast accessibility issues

### DIFF
--- a/src/components/navigation/Footer.tsx
+++ b/src/components/navigation/Footer.tsx
@@ -88,7 +88,7 @@ const BarStyled = styled(Bar)<BarSlotsProps>(({ theme }) => ({
   position: "relative",
   bottom: 0,
   marginTop: "auto",
-  backgroundColor: theme.vars.palette.primary.light,
+  backgroundColor: theme.vars.palette.primary.main,
 }));
 
 interface FooterProps extends BarSlotsProps {

--- a/src/themes/DiamondTheme.ts
+++ b/src/themes/DiamondTheme.ts
@@ -3,7 +3,6 @@ import { createTheme, Theme } from "@mui/material/styles";
 
 import { mergeThemeOptions } from "./ThemeManager";
 
-import logoImageDark from "../public/diamond/logo-dark.svg";
 import logoImageLight from "../public/diamond/logo-light.svg";
 import logoShort from "../public/diamond/logo-short.svg";
 
@@ -13,7 +12,7 @@ const dlsLogoYellow = "#facf07";
 const DiamondThemeOptions = mergeThemeOptions({
   logos: {
     normal: {
-      src: logoImageDark, // Use the dark image for light backgrounds
+      src: logoImageLight,
       srcDark: logoImageLight, // Use the light image for dark backgrounds
       alt: "Diamond Light Source Logo",
       width: "100",
@@ -48,9 +47,9 @@ const DiamondThemeOptions = mergeThemeOptions({
     dark: {
       palette: {
         primary: {
-          main: "#6175bd", //lightened version of {dlsLogoBlue}
+          main: "#435184", // mid blue
           light: "#8090CA", // lighter blue
-          dark: "#435184", // mid blue
+          dark: "#6175bd",
           contrastText: "#ffffff", // white
         },
         secondary: {


### PR DESCRIPTION
The best way I could see to correct the accessibility issue was to change the `main` colour code to that of the `dark` colour code for the dark theme. 

NavBar and Footer now pass accessibility checks. Also the table headers in apps will use the new `main` colour when in dark mode and also pass accessibility colour contrast wise.

Also changed the diamond theme to use the white text as looks better when in dark mode.

<img width="1032" height="143" alt="Screenshot From 2025-10-15 16-13-51" src="https://github.com/user-attachments/assets/b5a69c09-b1d8-45b2-a1f2-7a616f9b3ced" />

<img width="1032" height="143" alt="Screenshot From 2025-10-15 16-14-24" src="https://github.com/user-attachments/assets/ed68d9e9-bbed-4e3a-9cf8-70a66ed7470e" />
