### PR TITLE
Change Bar height to auto

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@ SciReactUI Changelog
 
 ### Fixed
 - Hovering over a slot caused a popup with the slot title in. This has been removed.
+- Stopped Bar-based components (e.g. Navbar, Footer) from expanding when a parent component has a set height
 
 ### Changed
 - Remove first-child css selector as it causes problems with server-side rendering.

--- a/src/components/controls/Bar.test.tsx
+++ b/src/components/controls/Bar.test.tsx
@@ -38,7 +38,7 @@ describe("Bar", () => {
     // check new style is set
     expect(headerComputedStyle.border).toBe(borderStyle);
     // Check default values are still set
-    expect(headerComputedStyle.height).toBe("100%");
+    expect(headerComputedStyle.height).toBe("auto");
   });
 });
 

--- a/src/components/controls/Bar.tsx
+++ b/src/components/controls/Bar.tsx
@@ -26,7 +26,7 @@ const Slot = ({ className, style, children }: SlotProps) => (
 
 const BoxStyled = styled(Box)<BoxProps>(({ theme }) => ({
   width: "100%",
-  height: "100%",
+  height: "auto",
   minHeight: "50px",
   display: "flex",
   alignItems: "center",

--- a/src/components/navigation/Navbar.test.tsx
+++ b/src/components/navigation/Navbar.test.tsx
@@ -24,7 +24,7 @@ describe("Navbar", () => {
     expect(headerComputedStyle.border).toBe(borderStyle);
 
     // Check default values are still set
-    expect(headerComputedStyle.height).toBe("100%");
+    expect(headerComputedStyle.height).toBe("auto");
   });
 });
 


### PR DESCRIPTION
Fixes #119 

I think this restores the intended behaviour of the Bar component, preventing it expanding:
```tsx
    <Stack height={500}>
    <AppTitlebar/>
    <Typography>
      App content
    </Typography>
    <Footer position={"fixed"} />
    </Stack>
```
<img width="813" height="499" alt="image" src="https://github.com/user-attachments/assets/d4df0fb6-a3e0-4ce0-98e8-929f4a79d963" />
