### PR TITLE
feat: add OSV Scanner workflow

### DIFF
--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -1,0 +1,26 @@
+name: OSV Scanner
+
+on:
+  pull_request:
+    branches: [main]
+  merge_group:
+    branches: [main]
+  push:
+    branches: [main]
+  schedule:
+    - cron: '0 3 * * *' # Daily at 03:00 UTC
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  scan-pr:
+    if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@v2.3.2
+
+  scan-scheduled:
+    if: github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@v2.3.2


### PR DESCRIPTION
## Summary

- Add automated vulnerability scanning using Google's OSV Scanner action (v2.3.2)
- Runs on PR (diff scan), push to main (full scan), daily at 03:00 UTC, and manual dispatch
- Reports findings via SARIF to GitHub Security tab

## Test plan

- [x] Verify workflow triggers on this PR
- [ ] Check Security tab for SARIF upload after merge