### PR TITLE
Fix dark mode colour scheme selector

### DIFF
--- a/src/themes/BaseTheme.ts
+++ b/src/themes/BaseTheme.ts
@@ -19,7 +19,7 @@ declare module "@mui/material/styles" {
 
 const BaseThemeOptions /* : ThemeOptions */ = {
   cssVariables: {
-    colorSchemeSelector: "class",
+    colorSchemeSelector: "data-mode",
   },
   typography: {
     fontSize: 14,


### PR DESCRIPTION
## Summary

- Change `colorSchemeSelector` in `BaseTheme` from `"class"` to `"data-mode"` so MUI toggles the `data-mode` attribute on the root element when `ColourSchemeButton` switches dark mode

**Note:** The ds-theme branch's `ThemeProvider` also needs a `ColorSchemeSync` fix (its `useLayoutEffect` sets `class` and `color-scheme` inline style from a static `mode` prop, which goes stale after toggling). That fix will go into ds-theme directly when it rebases on top of this.

Fixes #130