### PR TITLE
Suggested MUI component wrapper with a few examples.

### DIFF
--- a/src/components/MUI/MuiWrapped.tsx
+++ b/src/components/MUI/MuiWrapped.tsx
@@ -1,0 +1,7 @@
+import MuiWrapper from "./MuiWrapper";
+
+import MuiChip, { ChipProps as MuiChipProps } from "@mui/material/Chip";
+import MuiAlert, { AlertProps as MuiAlertProps } from "@mui/material/Alert";
+
+export const Chip = MuiWrapper<MuiChipProps>(MuiChip, "Chip");
+export const Alert = MuiWrapper<MuiAlertProps>(MuiAlert, "Alert");

--- a/src/components/MUI/MuiWrapper.tsx
+++ b/src/components/MUI/MuiWrapper.tsx
@@ -1,0 +1,13 @@
+import { forwardRef } from "react";
+
+export default function MuiWrapper<Prop, Element = HTMLDivElement>(
+  MuiComponent: any,
+  name: string,
+) {
+  const RefForward = forwardRef<Element, Prop>((props, ref) => (
+    <MuiComponent {...props} ref={ref} />
+  ));
+
+  RefForward.displayName = name;
+  return RefForward;
+}

--- a/src/components/MUI/MuiWrapper.tsx
+++ b/src/components/MUI/MuiWrapper.tsx
@@ -1,7 +1,7 @@
-import { forwardRef } from "react";
+import { ElementType, forwardRef } from "react";
 
 export default function MuiWrapper<Prop, Element = HTMLDivElement>(
-  MuiComponent: any,
+  MuiComponent: ElementType,
   name: string,
 ) {
   const RefForward = forwardRef<Element, Prop>((props, ref) => (


### PR DESCRIPTION
A component to wrap MUI components.

A couple of examples with Alert and Chip.

Note, that the default HTML Entity for the `forwardRef` is `HTMLDivElement` but this can be overridden with what ever you like.