### PR TITLE
Add Mac specific `DS_Store` file to git ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@
 .pnpm-store/
 
 tsconfig.tsbuildinfo
+
+# macOS
+.DS_Store


### PR DESCRIPTION
Added `.DS_Store` filename, which is created automaticallt to any folder by MacOS Finder