### PR TITLE
Update css for storybook to have more classes from variety of mdx files

### DIFF
--- a/.storybook/storybook.css
+++ b/.storybook/storybook.css
@@ -1,58 +1,238 @@
 :root {
-    --ds-font-body: 'Inter', system-ui, -apple-system, BlinkMacSystemFont,
-      'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
-  
-    --ds-font-heading: 'Outfit', system-ui, -apple-system, BlinkMacSystemFont,
-      'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
-  
-    --ds-font-mono: 'IBM Plex Mono', ui-monospace, SFMono-Regular, Menlo, Monaco,
-      Consolas, 'Liberation Mono', 'Courier New', monospace;
+  --sb-ds-font-body:
+    "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+    Helvetica, Arial, sans-serif;
+
+  --sb-ds-font-heading:
+    "Outfit", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+    Helvetica, Arial, sans-serif;
+
+  --sb-ds-font-mono:
+    "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+    "Liberation Mono", "Courier New", monospace;
+
+  --sb-ds-background: #f6f6f9;
+  --sb-ds-surface: #ffffff;
+  --sb-ds-surface-container: #eef1f5;
+  --sb-ds-surface-container-high: #e6e9f0;
+
+  --sb-ds-on-surface: #1a1c23;
+  --sb-ds-on-surface-variant: #505563;
+
+  --sb-ds-border-subtle: #dde1e8;
+
+  --sb-ds-grey-500: #a5acb8;
+  --sb-ds-primary: #0f62fe;
+  --sb-ds-secondary: #393939;
+  --sb-ds-success: #24a148;
+  --sb-ds-warning: #f1c21b;
+  --sb-ds-danger: #da1e28;
+  --sb-ds-info: #3d1380;
+  --sb-ds-brand: #0f62fe;
+}
+
+body .sbdocs {
+  background-color: var(--sb-ds-background) !important;
+}
+
+/* Base font */
+.sbdocs,
+.sbdocs p,
+.sbdocs li {
+  font-family: var(--sb-ds-font-body);
+  font-size: 16px;
+  line-height: 1.6;
+  color: var(--sb-ds-on-surface);
+}
+
+/* Headings use Outfit or Inter */
+
+.sbdocs h1 {
+  font-family: var(--sb-ds-font-heading);
+  color: var(--sb-ds-on-surface);
+}
+
+.sbdocs h2 {
+  font-family: var(--sb-ds-font-body);
+  color: var(--sb-ds-on-surface);
+  border-bottom: 1px solid var(--sb-ds-border-subtle);
+}
+
+.sbdocs h3,
+.sbdocs h4,
+.sbdocs h5,
+.sbdocs h6 {
+  font-family: var(--sb-ds-font-body);
+  color: var(--sb-ds-on-surface);
+}
+/* Code uses IBM Plex Mono */
+code,
+.sbdocs code,
+.sbdocs pre,
+.sbdocs kbd,
+.sbdocs samp,
+.token {
+  font-family: var(--sb-ds-font-mono);
+  font-size: 0.8rem;
+}
+
+/* For Component Preview, actual transition based on light/dark mode */
+.sbdocs-preview div[style*="background-color"] {
+  background-color: var(--ds-surface) !important;
+  color: var(--ds-on-surface) !important;
+}
+
+/* MDX file styling */
+.ds-docs {
+  max-width: 100ch;
+  color: var(--sb-ds-on-surface);
+}
+
+.ds-docs p {
+  max-width: 78ch;
+}
+
+/* MDX Components */
+
+.sbdocs code {
+  background-color: var(--sb-ds-surface-container) !important;
+  color: var(--sb-ds-on-surface) !important;
+  border: 1px solid var(--sb-ds-border-subtle) !important;
+  border-radius: 4px;
+  padding: 1px 4px;
+}
+
+.sbdocs pre {
+  padding: 16px !important;
+  background-color: var(--sb-ds-surface) !important;
+  border: 1px solid var(--sb-ds-border-subtle) !important;
+  border-radius: 12px;
+}
+
+/* Tables */
+.ds-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 16px 0 24px;
+  background: var(--sb-ds-surface);
+}
+.ds-table th {
+  color: var(--sb-ds-on-surface-variant);
+  background: var(--sb-ds-surface-container);
+}
+.ds-table td:first-child {
+  white-space: nowrap;
+}
+.ds-table th,
+.ds-table td {
+  font-family: var(--sb-ds-font-body);
+  border-bottom: 1px solid var(--sb-ds-border-subtle);
+  padding: 10px 12px;
+  text-align: left;
+  vertical-align: top;
+  color: var(--sb-ds-on-surface);
+  font-size: 0.9rem;
+  line-height: 1.6;
+}
+.ds-table td p {
+  font-size: 0.85rem; /* p in tables has a diffrent calculation fo size, so we try to align to the same size as the rest of the table */
+  line-height: 1.8;
+}
+.ds-table tr:nth-of-type(2n) {
+  background: var(--sb-ds-surface) !important;
+}
+
+/* To-dos */
+.ds-dos {
+  display: grid;
+  gap: 16px;
+  margin: 16px 0 24px;
+}
+@media (min-width: 800px) {
+  .ds-dos {
+    grid-template-columns: 1fr 1fr;
   }
-  
-  /* Docs root */
-  .sbdocs, .sbdocs p, .sbdocs li,.sb-unstyled, .sb-unstyled ul, .sb-unstyled li {
-    font-family: var(--ds-font-body);
-    font-size: 16px !important;
-    line-height: 1.6;
-  }
-  
-  /* Lists */
-  .sbdocs li {
-    font-size: 16px !important;
-  }
-  
-  /* Headings use Outfit or Inter */
-  
-  .sbdocs h1 {
-    font-family: var(--ds-font-heading);
-  }
-  
-  .sbdocs h3,
-  .sbdocs h4,
-  .sbdocs h5,
-  .sbdocs h6 {
-    font-family: var(--ds-font-body);
-  }
-  
-  /* Code uses IBM Plex Mono */
-  .sbdocs code,
-  .sbdocs pre,
-  .sbdocs kbd,
-  .sbdocs samp,
-  .token {
-    font-family: var(--ds-font-mono);
-    font-size: 1em;
-  }
-  
-  /* Neutralise Storybook Docs inline preview background wrapper */
-  .sbdocs-preview div[style*="background-color"], #storybook-root div[style*="background-color"] {
-    background-color: transparent !important;
-  }
-  
-  .light .sbdocs-preview div[style*="background-color"] {
-    background-color: #f6f6f6 !important;
-  }
-  
-  .dark .sbdocs-preview div[style*="background-color"]{
-    background-color: #212121   !important;
-  }
+}
+
+/* Note */
+.ds-note {
+  border: 1px solid var(--sb-ds-border-subtle);
+  background: var(--sb-ds-surface-container-high);
+  border-radius: 12px;
+  padding: 16px;
+  margin: 16px 0 24px;
+}
+
+/* Cards */
+.ds-card {
+  border: 1px solid var(--sb-ds-border-subtle);
+  background: var(--sb-ds-surface-container-high);
+  border-radius: 12px;
+  padding: 16px;
+}
+.ds-card h3 {
+  margin-top: 0;
+}
+.ds-card ul {
+  margin-bottom: 0;
+}
+
+/* Table of contents */
+.ds-toc {
+  display: grid;
+  gap: 6px;
+  border: 1px solid var(--sb-ds-border-subtle);
+  background: var(--sb-ds-surface-container);
+  border-radius: 12px;
+  padding: 16px;
+}
+.ds-toc li {
+  font-size: 0.9rem;
+}
+.ds-toc a {
+  color: var(--sb-ds-primary);
+  text-decoration: none;
+}
+.ds-toc a:hover {
+  text-decoration: underline;
+}
+/* Roles */
+.ds-role {
+  font-weight: 600;
+  padding-left: 8px;
+}
+
+/* Swatches */
+.ds-swatch {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border-radius: 999px;
+  margin-right: 8px;
+  vertical-align: middle;
+  border-bottom: 1px solid var(--sb-ds-border-subtle);
+}
+.ds-swatch-neutral {
+  background: var(--sb-ds-grey-500);
+}
+.ds-swatch-primary {
+  background: var(--sb-ds-primary);
+}
+.ds-swatch-secondary {
+  background: var(--sb-ds-secondary);
+}
+.ds-swatch-success {
+  background: var(--sb-ds-success);
+}
+.ds-swatch-warning {
+  background: var(--sb-ds-warning);
+}
+.ds-swatch-danger {
+  background: var(--sb-ds-danger);
+}
+.ds-swatch-info {
+  background: var(--sb-ds-info);
+}
+.ds-swatch-brand {
+  background: var(--sb-ds-brand);
+}

--- a/src/storybook/Installation.mdx
+++ b/src/storybook/Installation.mdx
@@ -3,16 +3,6 @@ import { Meta } from "@storybook/blocks";
 
 <Meta title="Installation" />
 
-<style>{`
-  .ds-docs {
-    max-width: 100ch;
-  }
-
-  .ds-docs p {
-    max-width: 78ch;
-  }
-`}</style>
-
 <div className="ds-docs">
 
 <div className="sb-container">

--- a/src/storybook/Overview.mdx
+++ b/src/storybook/Overview.mdx
@@ -2,16 +2,6 @@ import { Meta } from "@storybook/blocks";
 
 <Meta title="Overview" />
 
-<style>{`
-  .ds-docs {
-    max-width: 100ch;
-  }
-
-  .ds-docs p {
-    max-width: 78ch;
-  }
-`}</style>
-
 <div className="ds-docs">
 
 # Diamond Design System ❖


### PR DESCRIPTION
- Added more classes to the `storybook.css` file
- Make the values semi-hard-coded, from the `ds-theme` but only for light mode
- Remove reference to local styles in the main doc files (Overview and Installation)