### PR TITLE
Some updates to global sb css file

### DIFF
--- a/.storybook/storybook.css
+++ b/.storybook/storybook.css
@@ -94,7 +94,7 @@ code,
 
 /* MDX Components */
 
-.sbdocs code {
+.sbdocs .ds-docs code {
   background-color: var(--sb-ds-surface-container) !important;
   color: var(--sb-ds-on-surface) !important;
   border: 1px solid var(--sb-ds-border-subtle) !important;
@@ -102,11 +102,11 @@ code,
   padding: 1px 4px;
 }
 
-.sbdocs pre {
+.sbdocs .ds-docs pre {
   padding: 16px !important;
   background-color: var(--sb-ds-surface) !important;
   border: 1px solid var(--sb-ds-border-subtle) !important;
-  border-radius: 12px;
+  border-radius: 4px;
 }
 
 /* Tables */

--- a/.storybook/storybook.css
+++ b/.storybook/storybook.css
@@ -28,7 +28,7 @@
   --sb-ds-warning: #f1c21b;
   --sb-ds-danger: #da1e28;
   --sb-ds-info: #3d1380;
-  --sb-ds-brand: #0f62fe;
+  --sb-ds-brand: #202945;
 }
 
 body .sbdocs {
@@ -89,7 +89,12 @@ code,
 }
 
 .ds-docs p {
-  max-width: 78ch;
+  max-width: 66ch;
+}
+
+.ds-docs .lead p {
+  font-size: 1.25rem;
+  max-width: 58ch;
 }
 
 /* MDX Components */
@@ -102,11 +107,25 @@ code,
   padding: 1px 4px;
 }
 
-.sbdocs .ds-docs pre {
+.ds-docs pre.ds-code-block {
   padding: 16px !important;
   background-color: var(--sb-ds-surface) !important;
   border: 1px solid var(--sb-ds-border-subtle) !important;
   border-radius: 4px;
+}
+
+/* Links */
+
+.ds-docs a p {
+  color: var(--sb-ds-primary);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  padding: 2px 4px;
+}
+.ds-docs a:hover p:hover {
+  color: var(--sb-ds-brand);
+  background: var(--sb-ds-surface-container-high);
+  width: fit-content;
 }
 
 /* Tables */

--- a/.storybook/storybook.css
+++ b/.storybook/storybook.css
@@ -94,7 +94,7 @@ code,
 
 /* MDX Components */
 
-.sbdocs code {
+.sbdocs .ds-docs code {
   background-color: var(--sb-ds-surface-container) !important;
   color: var(--sb-ds-on-surface) !important;
   border: 1px solid var(--sb-ds-border-subtle) !important;
@@ -102,7 +102,7 @@ code,
   padding: 1px 4px;
 }
 
-.sbdocs pre {
+.sbdocs .ds-docs pre {
   padding: 16px !important;
   background-color: var(--sb-ds-surface) !important;
   border: 1px solid var(--sb-ds-border-subtle) !important;

--- a/src/storybook/Overview.mdx
+++ b/src/storybook/Overview.mdx
@@ -6,10 +6,10 @@ import { Meta } from "@storybook/blocks";
 
 # Diamond Design System ❖
 
-<p>
+<div className="lead">
   The design system for Diamond Light Source, providing a shared foundation for
   building clear, consistent, reliable, and predictable scientific interfaces.
-</p>
+</div>
 
 ## What the design system includes
 


### PR DESCRIPTION
- Updated pre code
- Updated line length and introduced lead text
- Updated brand color
- Added links

The `pre` element has a new class that needs to be applied for ds-docs.

<img width="1106" height="606" alt="Screenshot 2026-06-01 at 18 00 24" src="https://github.com/user-attachments/assets/cba2bd01-c5d1-4238-950e-89473002b6a2" />
