### PR TITLE
Add subcomponents to stories

### DIFF
--- a/src/components/controls/AppTitlebar.stories.tsx
+++ b/src/components/controls/AppTitlebar.stories.tsx
@@ -4,6 +4,7 @@ import { AppTitle, AppTitlebar } from "./AppTitlebar";
 const meta: Meta<typeof AppTitlebar> = {
   title: "Components/Controls/AppTitlebar",
   component: AppTitlebar,
+  subcomponents: { AppTitle },
   tags: ["autodocs"],
   parameters: {
     docs: {

--- a/src/components/navigation/Footer.stories.tsx
+++ b/src/components/navigation/Footer.stories.tsx
@@ -5,6 +5,7 @@ import { MockLink } from "../../utils/MockLink";
 const meta: Meta<typeof Footer> = {
   title: "Components/Navigation/Footer",
   component: Footer,
+  subcomponents: { FooterLink, FooterLinks },
   decorators: [(Story) => <Story />],
   tags: ["autodocs"],
   parameters: {

--- a/src/components/navigation/NavMenu.stories.tsx
+++ b/src/components/navigation/NavMenu.stories.tsx
@@ -7,6 +7,7 @@ import { MockLink } from "../../utils/MockLink";
 const meta: Meta<typeof NavMenu> = {
   title: "Components/Navigation/NavMenu",
   component: NavMenu,
+  subcomponents: { NavMenuLink },
   tags: ["autodocs"],
   parameters: {
     docs: {

--- a/src/components/navigation/Navbar.stories.tsx
+++ b/src/components/navigation/Navbar.stories.tsx
@@ -13,6 +13,7 @@ import { NavMenu, NavMenuLink } from "../navigation/NavMenu";
 const meta: Meta<typeof Navbar> = {
   title: "Components/Navigation/Navbar",
   component: Navbar,
+  subcomponents: { NavMenu, NavMenuLink, NavLink, NavLinks },
   tags: ["autodocs"],
 };
 


### PR DESCRIPTION
Adds subcomponents to Navbar, NavMenu, Footer and AppTitlebar stories. These show props, but do not add controls.
Closes #173 