### PR TITLE
Add interactivity to ColourSchemeButton stories & remove system theme resolution default from Storybook

### DIFF
--- a/.storybook/ThemeSwapper.tsx
+++ b/.storybook/ThemeSwapper.tsx
@@ -1,4 +1,4 @@
-import { useColorScheme } from "@mui/material";
+import { useColorScheme } from "@mui/material/styles";
 import * as React from "react";
 import { useEffect } from "react";
 
@@ -23,21 +23,20 @@ export const TextSystem = "Mode: System";
 const ThemeSwapper = ({ context, children }: ThemeSwapperProps) => {
   const { mode, systemMode, setMode } = useColorScheme();
 
+  const selectedThemeMode = context.globals.themeMode ?? TextSystem;
+
   useEffect(() => {
-    const selectedThemeMode = context.globals.themeMode ?? TextSystem;
+    const targetMode =
+      selectedThemeMode === TextLight
+        ? "light"
+        : selectedThemeMode === TextDark
+          ? "dark"
+          : "system";
 
-    if (selectedThemeMode === TextLight) {
-      setMode("light");
-      return;
+    if (mode !== targetMode) {
+      setMode(targetMode);
     }
-
-    if (selectedThemeMode === TextDark) {
-      setMode("dark");
-      return;
-    }
-
-    setMode("system");
-  }, [context.globals.themeMode, setMode]);
+  }, [selectedThemeMode, mode, systemMode, setMode]);
 
   const resolvedMode = mode === "system" ? systemMode : mode;
 

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -5,17 +5,10 @@ import "@fontsource-variable/inter";
 import "./storybook.css"; /* Storybook CSS override */
 import { ThemeProvider } from "../src";
 import { DiamondDSTheme } from "../src";
-import { ThemeSwapper, TextLight, TextDark, TextSystem } from "./ThemeSwapper";
+import { ThemeSwapper, TextLight, TextDark } from "./ThemeSwapper";
 import "../src/styles/diamondDS/DiamondDSTokens.css";
 
 const TextThemeDiamondDS = "Theme: DiamondDS";
-
-function resolveDefaultMode(selectedThemeMode: string) {
-  if (selectedThemeMode === TextLight) return "light";
-  if (selectedThemeMode === TextDark) return "dark";
-
-  return "system";
-}
 
 export const decorators = [
   (StoriesWithPadding: React.FC) => {
@@ -27,18 +20,18 @@ export const decorators = [
   },
 
   (Story, context) => {
-    const selectedThemeMode = context.globals.themeMode || TextSystem;
-
+    const disableThemeSwapper = context.parameters.disableThemeSwapper === true;
     return (
-      <ThemeProvider
-        theme={DiamondDSTheme}
-        defaultMode={resolveDefaultMode(selectedThemeMode)}
-      >
+      <ThemeProvider theme={DiamondDSTheme}>
         <CssBaseline />
 
-        <ThemeSwapper context={context}>
+        {disableThemeSwapper ? (
           <Story />
-        </ThemeSwapper>
+        ) : (
+          <ThemeSwapper context={context}>
+            <Story />
+          </ThemeSwapper>
+        )}
       </ThemeProvider>
     );
   },

--- a/src/components/controls/ColourSchemeButton.stories.tsx
+++ b/src/components/controls/ColourSchemeButton.stories.tsx
@@ -1,5 +1,6 @@
 import { Meta, StoryObj } from "@storybook/react";
 import { ColourSchemeButton } from "./ColourSchemeButton";
+import { TextLight, TextDark } from "../../../.storybook/ThemeSwapper";
 
 const meta: Meta<typeof ColourSchemeButton> = {
   title: "Components/Controls/ColourSchemeButton",
@@ -8,7 +9,8 @@ const meta: Meta<typeof ColourSchemeButton> = {
   parameters: {
     docs: {
       description: {
-        component: "Switch between dark and light modes.",
+        component:
+          "Interactively switch between dark and light modes (does not follow global theme switching above).",
       },
     },
   },
@@ -17,6 +19,30 @@ const meta: Meta<typeof ColourSchemeButton> = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
+export const Interactive: Story = {
+  parameters: {
+    disableThemeSwapper: true,
+  },
+};
+
 export const LightSelected: Story = {
-  args: {},
+  globals: {
+    themeMode: TextLight,
+  },
+  parameters: {
+    docs: {
+      disable: true,
+    },
+  },
+};
+
+export const DarkSelected: Story = {
+  globals: {
+    themeMode: TextDark,
+  },
+  parameters: {
+    docs: {
+      disable: true,
+    },
+  },
 };

--- a/src/components/controls/ColourSchemeButton.tsx
+++ b/src/components/controls/ColourSchemeButton.tsx
@@ -1,18 +1,20 @@
-import { IconButton, IconButtonProps, useColorScheme } from "@mui/material";
-
+import { IconButton, IconButtonProps } from "@mui/material";
+import { useColorScheme } from "@mui/material/styles";
 import LightModeIcon from "@mui/icons-material/LightMode";
 import BedtimeIcon from "@mui/icons-material/Bedtime";
 
 export const ColourSchemeButton = (props: IconButtonProps) => {
-  const { mode, setMode } = useColorScheme();
-  const isDark = mode === "dark";
+  const { mode, systemMode, setMode } = useColorScheme();
+
+  const resolvedMode = mode === "system" ? systemMode : mode;
+  const isDark = resolvedMode === "dark";
 
   return (
     <IconButton
-      aria-label={`Colour scheme switcher: ${mode}`}
+      aria-label={`Colour scheme switcher: ${resolvedMode ?? "unknown"}`}
       {...props}
       onClick={(event) => {
-        setMode?.(isDark ? "light" : "dark");
+        setMode(isDark ? "light" : "dark");
         props.onClick?.(event);
       }}
       sx={(theme) => ({

--- a/src/components/navigation/Navbar.stories.tsx
+++ b/src/components/navigation/Navbar.stories.tsx
@@ -9,6 +9,7 @@ import { MockLink } from "../../utils/MockLink";
 import { Logo } from "../controls/Logo";
 import { NavMenu, NavMenuLink } from "../navigation/NavMenu";
 import { Chip, Typography } from "../../components/MUI/MuiWrapped";
+import { TextLight, TextDark } from "../../../.storybook/ThemeSwapper";
 
 const meta: Meta<typeof Navbar> = {
   title: "Components/Navigation/Navbar",
@@ -57,6 +58,9 @@ export const All: Story = {
       </>
     ),
     logo: "theme",
+  },
+  parameters: {
+    disableThemeSwapper: true,
   },
 };
 
@@ -301,6 +305,9 @@ export const LinksInSlot: Story = {
     ),
     logo: "theme",
   },
+  parameters: {
+    disableThemeSwapper: true,
+  },
 };
 
 export const LinksAndMenus: Story = {
@@ -365,6 +372,7 @@ export const AllSlots: Story = {
     logo: "theme",
   },
 };
+
 export const WithLogin: Story = {
   args: {
     children: <User onLogin={() => {}} onLogout={() => {}} user={null} />,
@@ -373,4 +381,30 @@ export const WithLogin: Story = {
 
 export const Empty: Story = {
   args: {},
+};
+
+export const AllFixedLight: Story = {
+  ...All,
+  name: "All (Fixed Light)",
+  parameters: {
+    docs: {
+      disable: true,
+    },
+  },
+  globals: {
+    themeMode: TextLight,
+  },
+};
+
+export const AllFixedDark: Story = {
+  ...All,
+  name: "All (Fixed Dark)",
+  parameters: {
+    docs: {
+      disable: true,
+    },
+  },
+  globals: {
+    themeMode: TextDark,
+  },
 };


### PR DESCRIPTION
Adds colour scheme switching to ColourSchemeButton and Navbar stories plus "fixed" light/dark stories by adding disable ThemeSwapper param for stories.
In Storybook: only call setMode in stories if theme has changed; remove default mode resolution.
Import useColorScheme from "@mui/material/styles".