### PR TITLE
Remove reference to grey tokens in the DS

### DIFF
--- a/src/styles/diamondDS/DiamondDSTokens.css
+++ b/src/styles/diamondDS/DiamondDSTokens.css
@@ -1,3 +1,5 @@
+/* Diamond Design System Token list for Light and Dark modes
+
 /* Light mode semantic roles */
 :root,
 :root[data-mode="light"] {
@@ -44,6 +46,8 @@
 
   --ds-on-surface: #1a1c23;
   --ds-on-surface-variant: #505563;
+  --ds-on-surface-subtle: #6c7484;
+  --ds-on-surface-muted: #8a90a0;
   --ds-on-surface-disabled: rgba(0, 0, 0, 0.36);
   --ds-action-disabled: rgba(0, 0, 0, 0.3);
   --ds-on-solid: #ffffff;
@@ -284,6 +288,8 @@
 
   --ds-on-surface: #e8eaf0;
   --ds-on-surface-variant: #b6bcc9;
+  --ds-on-surface-subtle: #979eae;
+  --ds-on-surface-muted: #7c8394;
   --ds-on-surface-disabled: rgba(255, 255, 255, 0.36);
   --ds-action-disabled: rgba(255, 255, 255, 0.3);
   --ds-on-solid: #ffffff;
@@ -445,67 +451,3 @@
   --ds-highlight-lightChannel: 255 241 184;
   --ds-highlight-darkChannel: 255 234 160;
 }
-
-/* Elavation colors
-
-0: base paper, dialogs on clean surface
-1–3: cards, panels, raised sections
-4–8: menus, popovers, floating UI
-9–16: more obviously separated overlays
-17–24: rare, maximum lift
-
-Figma references:
-LIGHT
-elevation-0  = #FFFFFF
-elevation-1  = #FDFDFE
-elevation-2  = #FAFBFC
-elevation-3  = #F8F9FB
-elevation-4  = #F7F9FB
-elevation-5  = #F6F8FA
-elevation-6  = #F5F7F9
-elevation-7  = #F4F6F8
-elevation-8  = #F3F5F7
-elevation-9  = #F3F5F7
-elevation-10 = #F2F4F7
-elevation-11 = #F2F4F7
-elevation-12 = #F1F3F6
-elevation-13 = #F1F3F6
-elevation-14 = #F1F3F6
-elevation-15 = #F0F2F5
-elevation-16 = #F0F2F5
-elevation-17 = #F0F2F5
-elevation-18 = #EFF1F4
-elevation-19 = #EFF1F4
-elevation-20 = #EEF1F5
-elevation-21 = #EEF1F5
-elevation-22 = #EEF1F5
-elevation-23 = #EEF1F5
-elevation-24 = #EEF1F5
-
-DARK
-elevation-0  = #161820
-elevation-1  = #181B23
-elevation-2  = #191C25
-elevation-3  = #1A1E27
-elevation-4  = #1B1F28
-elevation-5  = #1C202A
-elevation-6  = #1E222C
-elevation-7  = #1F232D
-elevation-8  = #20242F
-elevation-9  = #20242F
-elevation-10 = #212631
-elevation-11 = #212631
-elevation-12 = #222632
-elevation-13 = #222632
-elevation-14 = #222632
-elevation-15 = #242935
-elevation-16 = #242935
-elevation-17 = #252A37
-elevation-18 = #262C39
-elevation-19 = #262C39
-elevation-20 = #28303C
-elevation-21 = #28303C
-elevation-22 = #2A3140
-elevation-23 = #2A3140
-elevation-24 = #2C3140
-*/

--- a/src/styles/diamondDS/DiamondDSTokens.css
+++ b/src/styles/diamondDS/DiamondDSTokens.css
@@ -1,27 +1,3 @@
-:root {
-  /* Neutral primitives */
-  --ds-grey-50: #f8f8fa;
-  --ds-grey-100: #eef1f5;
-  --ds-grey-200: #eaedf3;
-  --ds-grey-300: #dde1e8;
-  --ds-grey-400: #bcc2cd;
-  --ds-grey-500: #a5acb8;
-  --ds-grey-600: #8a90a0;
-  --ds-grey-700: #505563;
-  --ds-grey-800: #2c3140;
-  --ds-grey-900: #1a1c23;
-
-  --ds-grey-dark-50: #e8eaf0;
-  --ds-grey-dark-100: #b6bcc9;
-  --ds-grey-dark-200: #7c8394;
-  --ds-grey-dark-300: #505664;
-  --ds-grey-dark-400: #3a3f4c;
-  --ds-grey-dark-500: #2c3140;
-  --ds-grey-dark-600: #222632;
-  --ds-grey-dark-700: #161820;
-  --ds-grey-dark-800: #0e1017;
-}
-
 /* Light mode semantic roles */
 :root,
 :root[data-mode="light"] {
@@ -62,12 +38,12 @@
   --ds-surface: #ffffff;
   --ds-surface-channel: 255 255 255;
 
-  --ds-surface-container: var(--ds-grey-100);
-  --ds-surface-container-high: var(--ds-grey-200);
+  --ds-surface-container: #eef1f5;
+  --ds-surface-container-high: #e6e9f0;
   --ds-surface-disabled: rgba(0, 0, 0, 0.08);
 
-  --ds-on-surface: var(--ds-grey-900);
-  --ds-on-surface-variant: var(--ds-grey-700);
+  --ds-on-surface: #1a1c23;
+  --ds-on-surface-variant: #505563;
   --ds-on-surface-disabled: rgba(0, 0, 0, 0.36);
   --ds-action-disabled: rgba(0, 0, 0, 0.3);
   --ds-on-solid: #ffffff;
@@ -75,12 +51,12 @@
   --ds-on-surface-channel: 26 28 35;
   --ds-on-surface-variant-channel: 80 85 99;
 
-  --ds-placeholder: var(--ds-grey-600);
-  --ds-placeholder-focus: var(--ds-grey-700);
+  --ds-placeholder: #8a90a0;
+  --ds-placeholder-focus: #505563;
 
-  --ds-border-subtle: var(--ds-grey-300);
-  --ds-border-emphasis: var(--ds-grey-400);
-  --ds-border-strong: var(--ds-grey-500);
+  --ds-border-subtle: #dde1e8;
+  --ds-border-emphasis: #bcc2cd;
+  --ds-border-strong: #a5acb8;
   --ds-border-subtle-channel: 221 225 232;
 
   /* Interaction overlays
@@ -296,18 +272,18 @@
   --ds-elevation-24: #2c3140;
 
   /* Neutral roles */
-  --ds-background: var(--ds-grey-dark-800);
+  --ds-background: #0e1017;
   --ds-background-channel: 14 16 23;
 
-  --ds-surface: var(--ds-grey-dark-700);
+  --ds-surface: #161820;
   --ds-surface-channel: 22 24 32;
 
-  --ds-surface-container: var(--ds-grey-dark-600);
-  --ds-surface-container-high: var(--ds-grey-dark-500);
+  --ds-surface-container: #222632;
+  --ds-surface-container-high: #2c3140;
   --ds-surface-disabled: rgba(255, 255, 255, 0.14);
 
-  --ds-on-surface: var(--ds-grey-dark-50);
-  --ds-on-surface-variant: var(--ds-grey-dark-100);
+  --ds-on-surface: #e8eaf0;
+  --ds-on-surface-variant: #b6bcc9;
   --ds-on-surface-disabled: rgba(255, 255, 255, 0.36);
   --ds-action-disabled: rgba(255, 255, 255, 0.3);
   --ds-on-solid: #ffffff;
@@ -315,12 +291,12 @@
   --ds-on-surface-channel: 232 234 240;
   --ds-on-surface-variant-channel: 182 188 201;
 
-  --ds-placeholder: var(--ds-grey-dark-200);
-  --ds-placeholder-focus: var(--ds-grey-dark-100);
+  --ds-placeholder: #7c8394;
+  --ds-placeholder-focus: #b6bcc9;
 
-  --ds-border-subtle: var(--ds-grey-dark-400);
-  --ds-border: var(--ds-grey-dark-300);
-  --ds-border-emphasis: var(--ds-grey-dark-200);
+  --ds-border-subtle: #3a3f4c;
+  --ds-border: #505664;
+  --ds-border-emphasis: #7c8394;
   --ds-border-subtle-channel: 58 63 76;
 
   /* Interaction overlays */

--- a/src/themes/DiamondDSTheme.ts
+++ b/src/themes/DiamondDSTheme.ts
@@ -164,8 +164,15 @@ declare module "@mui/material/styles" {
   }
 
   interface TypeText {
+    /** Adding more subtleties to text colours */
+    tertiary?: string;
+    muted?: string;
+
+    /** Input placeholder text. Kept here for MUI compatibility. */
     placeholder?: string;
     placeholderFocus?: string;
+
+    /** Text/icons placed on solid coloured surfaces. */
     onSolid?: string;
     primaryChannel?: string;
     secondaryChannel?: string;
@@ -174,6 +181,8 @@ declare module "@mui/material/styles" {
   interface TypeTextOptions {
     primary?: string;
     secondary?: string;
+    tertiary?: string;
+    muted?: string;
     disabled?: string;
     placeholder?: string;
     placeholderFocus?: string;
@@ -506,6 +515,8 @@ const createDiamondPalette = (mode: DSMode) => {
     text: {
       primary: "var(--ds-on-surface)",
       secondary: "var(--ds-on-surface-variant)",
+      tertiary: "var(--ds-on-surface-subtle)",
+      muted: "var(--ds-on-surface-muted)",
       onSolid: "var(--ds-on-solid)",
       disabled: "var(--ds-on-surface-disabled)",
       placeholder: "var(--ds-placeholder)",


### PR DESCRIPTION
Updated theme greys and new tokens
Remove reference to grey tokens in the DS
Added subtle and muted neutral texts

Reasoning:
- primitives are not used anymore by the theme itself.
- it was too restricting for granular changes, not used in all colours, so keeping it consistent on the

This replaces #229 