### PR TITLE
Fix Navbar on small screens

### DIFF
--- a/src/components/navigation/Navbar.tsx
+++ b/src/components/navigation/Navbar.tsx
@@ -89,6 +89,7 @@ const NavLinks = ({ children }: NavLinksProps) => {
       <Drawer open={isOpen} onClose={onClose} anchor="left">
         <Bar surface="brand" variant="solid" sx={{ height: "100%" }}>
           <Box
+            onClick={onClose}
             sx={{
               p: 2,
               display: "flex",

--- a/src/components/navigation/Navbar.tsx
+++ b/src/components/navigation/Navbar.tsx
@@ -124,6 +124,8 @@ const Navbar = ({
   children,
   ...props
 }: NavbarProps) => {
+  const forceOnDarkLogo = surface === "brand" || surface === "brand-fixed";
+
   return (
     <Bar
       {...props}
@@ -165,7 +167,11 @@ const Navbar = ({
                         height: "100%",
                       }}
                     >
-                      <Logo tone="inverse" short />
+                      <Logo
+                        fixedTone={forceOnDarkLogo ? "dark" : undefined}
+                        tone="inverse"
+                        short
+                      />
                     </Box>
                     <Box
                       sx={{
@@ -174,7 +180,10 @@ const Navbar = ({
                         height: "100%",
                       }}
                     >
-                      <Logo tone="inverse" />
+                      <Logo
+                        fixedTone={forceOnDarkLogo ? "dark" : undefined}
+                        tone="inverse"
+                      />
                     </Box>
                   </>
                 ) : (

--- a/src/components/navigation/Navbar.tsx
+++ b/src/components/navigation/Navbar.tsx
@@ -156,7 +156,26 @@ const Navbar = ({
                 }}
               >
                 {logo == "theme" ? (
-                  <Logo tone="inverse" />
+                  <>
+                    <Box
+                      sx={{
+                        display: { xs: "flex", md: "none" },
+                        alignItems: "center",
+                        height: "100%",
+                      }}
+                    >
+                      <Logo tone="inverse" short />
+                    </Box>
+                    <Box
+                      sx={{
+                        display: { xs: "none", md: "flex" },
+                        alignItems: "center",
+                        height: "100%",
+                      }}
+                    >
+                      <Logo tone="inverse" />
+                    </Box>
+                  </>
                 ) : (
                   <ImageColourSchemeSwitch image={logo} />
                 )}

--- a/src/components/navigation/Navbar.tsx
+++ b/src/components/navigation/Navbar.tsx
@@ -69,7 +69,7 @@ const NavLinks = ({ children }: NavLinksProps) => {
         size="small"
         aria-label="Open Menu"
         onClick={isOpen ? onClose : onOpen}
-        sx={{ display: { md: "none" }, order: -1 }}
+        sx={{ display: { md: "none" }, order: -1, color: "inherit" }}
       >
         {isOpen ? <MdClose /> : <MdMenu />}
       </IconButton>
@@ -152,6 +152,7 @@ const Navbar = ({
                   },
                   "&:hover": { opacity: 0.8 },
                   mr: { xs: 0, md: 5 },
+                  ml: { xs: 2, md: 0 },
                 }}
               >
                 {logo == "theme" ? (


### PR DESCRIPTION
Make Navbar hamburger icon match Navlink colour
Use short logo on small screens
Close side drawer when links clicked
Add padding between hamburger icon and logo on small screens
Force "on dark" logo in light/dark when using brand or brandFixed for Navbar

Old version with black menu icon and no spacing between menu icon and logo
<img width="835" height="60" alt="Screenshot 2026-06-23 at 11 06 28" src="https://github.com/user-attachments/assets/f3d06b39-80e6-4c1a-95d5-6dd5b22cd448" />

New version with logo spacing, short logo and menu colour matching link typography colour
<img width="822" height="45" alt="Screenshot 2026-06-23 at 11 06 00" src="https://github.com/user-attachments/assets/f2138f03-cd46-4e02-a610-eb4411c5a152" />

"on dark logo" in dark mode:
<img width="988" height="54" alt="Screenshot 2026-06-23 at 11 16 11" src="https://github.com/user-attachments/assets/fbdc9ace-ba12-4252-ae07-d1673f6aa7da" />




