### PR TITLE
fix: update ColourSchemeButton and dev index to fix flash

### DIFF
--- a/dev/index.html
+++ b/dev/index.html
@@ -6,6 +6,14 @@
     <title>SciReactUI Dev</title>
   </head>
   <body>
+    <script>
+      (function () {
+        var mode = localStorage.getItem("mui-mode");
+        if (mode) {
+          document.documentElement.setAttribute("data-mode", mode);
+        }
+      })();
+    </script>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/src/components/controls/ColourSchemeButton.test.tsx
+++ b/src/components/controls/ColourSchemeButton.test.tsx
@@ -1,29 +1,42 @@
 import { fireEvent } from "@testing-library/react";
+import { useColorScheme } from "@mui/material/styles";
 
 import { ColourSchemeButton } from "./ColourSchemeButton";
-import { ColourSchemes } from "../../utils/globals";
 import { renderWithProviders } from "../../__test-utils__/helpers";
 
 const mockSetColorScheme = vi.fn();
-vi.mock("@mui/material", async () => {
-  const actualEnums = await vi.importActual("../../utils/globals");
+vi.mock("@mui/material/styles", async () => {
+  const actual = await vi.importActual<typeof import("@mui/material/styles")>(
+    "@mui/material/styles",
+  );
 
   return {
-    ...(await vi.importActual("@mui/material")),
-    useColorScheme: vi.fn().mockReturnValue({
-      // @ts-expect-error module doesn't have a type
-      colorScheme: actualEnums.ColourSchemes.Dark,
-      setColorScheme: (scheme: ColourSchemes) => mockSetColorScheme(scheme),
-    }),
+    ...actual,
+    useColorScheme: vi.fn(),
   };
 });
 
+const mockUseColorScheme = vi.mocked(useColorScheme);
+
 describe("ColourSchemeButton", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockUseColorScheme.mockReturnValue({
+      mode: "dark",
+      systemMode: undefined,
+      setMode: mockSetColorScheme,
+      colorScheme: "dark",
+      allColorSchemes: ["light", "dark"],
+      setColorScheme: vi.fn(),
+    });
+  });
+
   it("should render without errors", () => {
     renderWithProviders(<ColourSchemeButton />);
   });
 
-  it("should show dark icon and button", () => {
+  it("should show button and light mode icon when current mode is dark", () => {
     const { getByTestId, getByRole } = renderWithProviders(
       <ColourSchemeButton />,
     );
@@ -31,7 +44,7 @@ describe("ColourSchemeButton", () => {
     const button = getByRole("button");
     expect(button).toBeInTheDocument();
 
-    const icon = getByTestId("BedtimeIcon");
+    const icon = getByTestId("LightModeIcon");
     expect(icon).toBeInTheDocument();
   });
 
@@ -41,7 +54,7 @@ describe("ColourSchemeButton", () => {
     const button = getByRole("button");
     fireEvent.click(button);
 
-    //expect(mockSetColorScheme).toHaveBeenCalledWith(ColourSchemes.Light);
+    expect(mockSetColorScheme).toHaveBeenCalledWith("light");
   });
 
   it("should call local onclick when button clicked", () => {
@@ -54,5 +67,20 @@ describe("ColourSchemeButton", () => {
     fireEvent.click(button);
 
     expect(mockOnClick).toHaveBeenCalled();
+  });
+
+  it("should not render while colour scheme is unresolved", () => {
+    mockUseColorScheme.mockReturnValue({
+      mode: undefined,
+      systemMode: undefined,
+      setMode: mockSetColorScheme,
+      colorScheme: undefined,
+      allColorSchemes: ["light", "dark"],
+      setColorScheme: vi.fn(),
+    });
+
+    const { queryByRole } = renderWithProviders(<ColourSchemeButton />);
+
+    expect(queryByRole("button")).not.toBeInTheDocument();
   });
 });

--- a/src/components/controls/ColourSchemeButton.tsx
+++ b/src/components/controls/ColourSchemeButton.tsx
@@ -9,6 +9,10 @@ export const ColourSchemeButton = (props: IconButtonProps) => {
   const resolvedMode = mode === "system" ? systemMode : mode;
   const isDark = resolvedMode === "dark";
 
+  if (resolvedMode === undefined) {
+    return null;
+  }
+
   return (
     <IconButton
       aria-label={`Colour scheme switcher: ${resolvedMode ?? "unknown"}`}

--- a/src/storybook/Installation.mdx
+++ b/src/storybook/Installation.mdx
@@ -161,35 +161,67 @@ Use this page to install SciReactUI, configure the Diamond Design System theme, 
 
 </div>
 
-  <div className="sb-container">
-    <div className='sb-section-title'>
-    ### Avoiding Dark Mode Flicker in SSR Apps
+<div className="sb-container">
+  <div className="sb-section-title">
 
-    To prevent a flash of incorrect theme (e.g. light mode before switching to dark), include the `InitColorSchemeScript` in your app code.
+    ### Avoiding Dark Mode Flicker
 
-    This ensures the correct colour scheme is applied immediately, based on system preference or saved user choice.
+    Applications that support dark mode may briefly render the default colour scheme before the user's preferred mode is applied.
 
+    #### SSR Applications
 
-      ```tsx filename="main.tsx"
-      import { InitColorSchemeScript } from "@mui/material";
+    To prevent a flash of incorrect theme in SSR applications, use MUI's `InitColorSchemeScript` and place it before your application content so the correct colour scheme is applied before hydration.
+    For example, for Next.js App Router:
+    ```tsx filename="layout.tsx"
+    import InitColorSchemeScript from '@mui/material/InitColorSchemeScript';
 
-      function Root() {
-        return (
-          <>
-            <InitColorSchemeScript attribute="[data-mode='%s']" />
-            <App />
-          </>
-        );
-      }
-      ```
+    export default function RootLayout(props: { children: React.ReactNode }) {
+    return (
+        <html lang="en" suppressHydrationWarning>
+        <body>
+            <InitColorSchemeScript attribute="data" />
+            {props.children}
+        </body>
+        </html>
+    );
+    }
+    ```
+    If your app renders into `index.html`, place the script at the top of the body so the mode is set before React mounts.
+    For more info see MUI's documentation on [InitColorSchemeScript](https://v7.mui.com/material-ui/react-init-color-scheme-script/).
 
-      If your app renders into `index.html`, place the script at the top of the body so the mode is set before React mounts.
+    #### Client-Side Applications (Vite etc.)
 
-      This helps avoid the brief light-mode flash when the user prefers dark mode.
+    For client-side applications, initialise the mode before React mounts:
+    ```
+    <body>
+        <script>
+        (function () {
+            var mode = localStorage.getItem("mui-mode");
+            if (mode) {
+            document.documentElement.setAttribute("data-mode", mode);
+            }
+        })();
+        </script>
+        <div id="root"></div>
+        <script type="module" src="/src/main.tsx"></script>
+    </body>
+    ```
 
-      For more info see MUI's documentation on [InitColorSchemeScript](https://v7.mui.com/material-ui/react-init-color-scheme-script/).
+    This ensures the correct DiamondDS token set is applied before the first paint, avoiding a flash of the default colour scheme when a saved preference exists.
 
-    </div>
+    DiamondDS uses:
+    ```
+    <html data-mode="light">
+    ```
+    or
+    ```
+    <html data-mode="dark">
+    ```
+    and should be configured with
+    ```
+    colorSchemeSelector: '[data-mode="%s"]'
+    ```
 
+  </div>
   </div>
 </div>


### PR DESCRIPTION
This PR:
- Updates guidance for using MUI's `InitColorSchemeScript` in SSR applications.
- Adds guidance for client-side applications (Vite etc.) to initialise data-mode before React mounts.
- Updates `ColourSchemeButton` to avoid rendering while the colour scheme is unresolved.
- Updates `ColourSchemeButton` tests to reflect the use of dark (moon) icon in light mode.

Dark mode flicker was being caused by the page initially rendering without a data-mode attribute. The default light token set was applied before React and MUI restored the user's saved preference. The script applies the correct mode before the first paint. The `ColourSchemeButton` now waits for MUI to resolve the active mode before rendering, avoiding initially showing the wrong icon. Placing `InitColorSchemeScript` in main.tsx is not correct as it runs too late after React has mounted.

Flash still visible in the dev app because Vite injects CSS dynamically via JavaScript during development for fast HMR, but production builds extract and load CSS ahead of app rendering. We may want to look into extracting css file. See https://www.xjavascript.com/blog/how-to-extract-css-as-a-separate-css-file-in-vite/