### PR TITLE
Fix transition animation flicker through ColourSchemeButton

### DIFF
--- a/src/components/controls/ColourSchemeButton.tsx
+++ b/src/components/controls/ColourSchemeButton.tsx
@@ -7,15 +7,16 @@ export const ColourSchemeButton = (props: IconButtonProps) => {
   const { mode, systemMode, setMode } = useColorScheme();
 
   const resolvedMode = mode === "system" ? systemMode : mode;
-  const isDark = resolvedMode === "dark";
 
-  if (resolvedMode === undefined) {
+  if (resolvedMode !== "light" && resolvedMode !== "dark") {
     return null;
   }
 
+  const isDark = resolvedMode === "dark";
+
   return (
     <IconButton
-      aria-label={`Colour scheme switcher: ${resolvedMode ?? "unknown"}`}
+      aria-label={`Colour scheme switcher: ${resolvedMode}`}
       {...props}
       onClick={(event) => {
         setMode(isDark ? "light" : "dark");
@@ -28,6 +29,7 @@ export const ColourSchemeButton = (props: IconButtonProps) => {
         borderRadius: 1,
         backgroundColor: theme.palette.surface.strong,
         color: theme.palette.text.primary,
+
         "&:hover": {
           backgroundColor: theme.palette.surface.strong,
           borderColor: theme.palette.border.subtle,

--- a/src/themes/ThemeProvider.tsx
+++ b/src/themes/ThemeProvider.tsx
@@ -1,10 +1,14 @@
-import { ThemeProvider as MuiThemeProvider } from "@mui/material/styles";
-import { CssBaseline } from "@mui/material";
-import { ThemeProviderProps as MuiThemeProviderProps } from "@mui/material/styles";
+import { useEffect, useRef } from "react";
+import { CssBaseline, GlobalStyles } from "@mui/material";
+import {
+  ThemeProvider as MuiThemeProvider,
+  ThemeProviderProps as MuiThemeProviderProps,
+} from "@mui/material/styles";
 import { DiamondDSTheme } from "./DiamondDSTheme";
 
 interface ThemeProviderProps extends Partial<MuiThemeProviderProps> {
   baseline?: boolean;
+  modeTransitionSuppressionMs?: number;
 }
 
 const ThemeProvider = function ({
@@ -12,11 +16,56 @@ const ThemeProvider = function ({
   theme = DiamondDSTheme,
   baseline = true,
   defaultMode = "system",
+  modeTransitionSuppressionMs = 250,
   ...props
 }: ThemeProviderProps) {
+  const timeoutRef = useRef<number | undefined>(undefined);
+
+  useEffect(() => {
+    const root = document.documentElement;
+
+    const observer = new MutationObserver(() => {
+      root.classList.add("ds-mode-changing");
+
+      if (timeoutRef.current !== undefined) {
+        window.clearTimeout(timeoutRef.current);
+      }
+
+      timeoutRef.current = window.setTimeout(() => {
+        root.classList.remove("ds-mode-changing");
+        timeoutRef.current = undefined;
+      }, modeTransitionSuppressionMs);
+    });
+
+    observer.observe(root, {
+      attributes: true,
+      attributeFilter: ["data-mode"],
+    });
+
+    return () => {
+      observer.disconnect();
+      if (timeoutRef.current !== undefined) {
+        window.clearTimeout(timeoutRef.current);
+        timeoutRef.current = undefined;
+      }
+
+      root.classList.remove("ds-mode-changing");
+    };
+  }, [modeTransitionSuppressionMs]);
+
   return (
     <MuiThemeProvider theme={theme} defaultMode={defaultMode} {...props}>
       {baseline && <CssBaseline />}
+
+      <GlobalStyles
+        styles={{
+          "html.ds-mode-changing *, html.ds-mode-changing *::before, html.ds-mode-changing *::after":
+            {
+              transition: "none !important",
+            },
+        }}
+      />
+
       {children}
     </MuiThemeProvider>
   );


### PR DESCRIPTION
Switching between light and dark mode caused a noticeable flicker as components transitioned before the new colour scheme had fully applied. This happened in internal components such as Chips and external ones such as Material React Table.

This fix adds a temporary `ds-mode-changing` class during colour scheme changes to suppress CSS transitions and animations until the new theme has been applied, reducing flicker during mode switching.

The CSS and the class were added to the `ColourSchemeButton` directly.