### PR TITLE
Make intent colours with higher contrast

### DIFF
--- a/src/styles/diamondDS/DiamondDSTokens.css
+++ b/src/styles/diamondDS/DiamondDSTokens.css
@@ -158,7 +158,7 @@
   --ds-brand-emphasis-channel: 23 31 53;
 
   /* Danger (Red) */
-  --ds-danger: #b42318;
+  --ds-danger: #ae1e13;
   --ds-on-danger: #ffffff;
   --ds-danger-emphasis: #912018;
   --ds-danger-accent: #d94f45;
@@ -168,14 +168,14 @@
   --ds-on-danger-solid: #ffffff;
 
   --ds-on-danger-channel: 255 255 255;
-  --ds-danger-channel: 180 35 24;
+  --ds-danger-channel: 174 30 19;
   --ds-danger-accent-channel: 217 79 69;
   --ds-danger-emphasis-channel: 145 32 24;
 
   /* Warning (Orange) */
-  --ds-warning: #c96a04;
+  --ds-warning: #a95703;
   --ds-on-warning: #ffffff;
-  --ds-warning-emphasis: #a95703;
+  --ds-warning-emphasis: #944b00;
   --ds-warning-accent: #e98a15;
   --ds-warning-container: #fef0df;
   --ds-on-warning-container: #6f3200;
@@ -183,22 +183,22 @@
   --ds-on-warning-solid: #ffffff;
 
   --ds-on-warning-channel: 255 255 255;
-  --ds-warning-channel: 201 106 4;
+  --ds-warning-channel: 169 87 3;
   --ds-warning-accent-channel: 233 138 21;
-  --ds-warning-emphasis-channel: 169 87 3;
+  --ds-warning-emphasis-channel: 148 75 0;
 
   /* Success (Green) */
-  --ds-success: #187a2f;
+  --ds-success: #137329;
   --ds-on-success: #ffffff;
   --ds-success-emphasis: #146125;
   --ds-success-accent: #2fb344;
-  --ds-success-container: #e3f4e7;
-  --ds-on-success-container: #124d22;
+  --ds-success-container: #d4f3df;
+  --ds-on-success-container: #0d491d;
   --ds-success-solid: #1b8834;
   --ds-on-success-solid: #ffffff;
 
   --ds-on-success-channel: 255 255 255;
-  --ds-success-channel: 24 122 47;
+  --ds-success-channel: 19 115 41;
   --ds-success-accent-channel: 47 179 68;
   --ds-success-emphasis-channel: 20 97 37;
 

--- a/src/themes/DiamondDSTheme.ts
+++ b/src/themes/DiamondDSTheme.ts
@@ -291,19 +291,19 @@ const paletteAdapterValues: Record<DSMode, Record<string, PaletteAdapter>> = {
     },
     danger: {
       light: "#d94f45", // --ds-danger-accent
-      main: "#b42318", // --ds-danger
+      main: "#ae1e13", // --ds-danger
       dark: "#912018", // --ds-danger-emphasis
       contrastText: "#ffffff", // --ds-on-danger
     },
     warning: {
       light: "#e98a15", // --ds-warning-accent
-      main: "#c96a04", // --ds-warning
-      dark: "#a95703", // --ds-warning-emphasis
+      main: "#a95703", // --ds-warning
+      dark: "#944b00", // --ds-warning-emphasis
       contrastText: "#ffffff", // --ds-on-warning
     },
     success: {
       light: "#2fb344", // --ds-success-accent
-      main: "#187a2f", // --ds-success
+      main: "#137329", // --ds-success
       dark: "#146125", // --ds-success-emphasis
       contrastText: "#ffffff", // --ds-on-success
     },


### PR DESCRIPTION
- danger (`--ds-danger`)
- warning (`--ds-warning`, `--ds-warning-emphasis`)
- success (`--ds-success`, `--ds-success-container`, `--ds-on-success-container`).
- Light only
- Update hardcoded fall backs and rgb values

<img width="780" height="599" alt="image" src="https://github.com/user-attachments/assets/3b0140a7-18dc-450a-8b4e-da9512d24cb7" />
