### PR TITLE
Updated docs theme colours and add reference to highlight and tertiary

### DIFF
--- a/.storybook/storybook.css
+++ b/.storybook/storybook.css
@@ -410,7 +410,7 @@ pre .language-tsx:not(.MuiTypography-root) {
 
 .ds-intent-grid {
   display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 16px;
 }
 
@@ -575,6 +575,28 @@ section.ds-mode-panel section {
   background: var(--ds-on-tertiary-solid);
 }
 
+.ds-bg-highlight-main {
+  background: var(--ds-highlight);
+}
+.ds-bg-highlight-dark {
+  background: var(--ds-highlight-emphasis);
+}
+.ds-bg-highlight-light {
+  background: var(--ds-highlight-accent);
+}
+.ds-bg-highlight-container {
+  background: var(--ds-highlight-container);
+}
+.ds-bg-highlight-on-container {
+  background: var(--ds-on-highlight-container);
+}
+.ds-bg-highlight-solid {
+  background: var(--ds-highlight-solid);
+}
+.ds-bg-highlight-on-solid {
+  background: var(--ds-on-highlight-solid);
+}
+
 .ds-bg-brand-main {
   background: var(--ds-brand);
 }
@@ -694,6 +716,36 @@ section.ds-mode-panel section {
   background: var(--ds-on-info-solid);
 }
 
+/* Contrast text (onPrimary, onDanger, etc.) shown as its own swatch */
+
+.ds-bg-on-primary {
+  background: var(--ds-on-primary);
+}
+.ds-bg-on-secondary {
+  background: var(--ds-on-secondary);
+}
+.ds-bg-on-tertiary {
+  background: var(--ds-on-tertiary);
+}
+.ds-bg-on-brand {
+  background: var(--ds-on-brand);
+}
+.ds-bg-on-danger {
+  background: var(--ds-on-danger);
+}
+.ds-bg-on-warning {
+  background: var(--ds-on-warning);
+}
+.ds-bg-on-success {
+  background: var(--ds-on-success);
+}
+.ds-bg-on-info {
+  background: var(--ds-on-info);
+}
+.ds-bg-on-highlight {
+  background: var(--ds-on-highlight);
+}
+
 /* Foregrounds */
 
 .ds-fg-primary-contrast,
@@ -703,7 +755,8 @@ section.ds-mode-panel section {
 .ds-fg-danger-contrast,
 .ds-fg-warning-contrast,
 .ds-fg-success-contrast,
-.ds-fg-info-contrast {
+.ds-fg-info-contrast,
+.ds-fg-highlight-contrast {
   color: var(--ds-on-solid);
 }
 
@@ -737,6 +790,40 @@ section.ds-mode-panel section {
 
 .ds-fg-info-contrast {
   color: var(--ds-on-info);
+}
+
+.ds-fg-highlight-contrast {
+  color: var(--ds-on-highlight);
+}
+
+/* Paired with the on-X backgrounds above so contrastText swatches stay legible */
+
+.ds-fg-primary-main {
+  color: var(--ds-primary);
+}
+.ds-fg-secondary-main {
+  color: var(--ds-secondary);
+}
+.ds-fg-tertiary-main {
+  color: var(--ds-tertiary);
+}
+.ds-fg-brand-main {
+  color: var(--ds-brand);
+}
+.ds-fg-danger-main {
+  color: var(--ds-danger);
+}
+.ds-fg-warning-main {
+  color: var(--ds-warning);
+}
+.ds-fg-success-main {
+  color: var(--ds-success);
+}
+.ds-fg-info-main {
+  color: var(--ds-info);
+}
+.ds-fg-highlight-main {
+  color: var(--ds-highlight);
 }
 
 .ds-fg-primary-container {
@@ -794,6 +881,19 @@ section.ds-mode-panel section {
 }
 .ds-fg-tertiary-on-fixed {
   color: var(--ds-on-tertiary-fixed);
+}
+
+.ds-fg-highlight-container {
+  color: var(--ds-highlight-container);
+}
+.ds-fg-highlight-on-container {
+  color: var(--ds-on-highlight-container);
+}
+.ds-fg-highlight-solid {
+  color: var(--ds-highlight-solid);
+}
+.ds-fg-highlight-on-solid {
+  color: var(--ds-on-highlight-solid);
 }
 
 .ds-fg-brand-container {

--- a/src/storybook/foundation/1.1. theme-colours.mdx
+++ b/src/storybook/foundation/1.1. theme-colours.mdx
@@ -21,22 +21,97 @@ This page is a token reference. If you're deciding which colour role to use, rea
  <section className="ds-mode-panel" data-mode="light">
   <section>
    <h3>Intent colours</h3>
+   <p>
+    Exposed as MUI palette roles (e.g. <code>theme.palette.primary.main</code>
+    ).
+   </p>
    <div className="ds-intent-grid">
     {[
      ["primary", "Primary", false],
      ["secondary", "Secondary", false],
-     ["tertiary", "Tertiary", false],
-     ["brand", "Brand", true],
+     ["info", "Info", false],
      ["danger", "Danger", false],
      ["warning", "Warning", false],
      ["success", "Success", false],
-     ["info", "Info", false],
     ].map(([key, label, hasFixed]) => (
      <div className="ds-colour-family" key={key}>
       <div className="ds-colour-stack">
        <div className={`ds-colour-row ds-bg-${key}-main ds-fg-${key}-contrast`}>
         <span>{label}</span>
         <code>main</code>
+       </div>
+       <div className={`ds-colour-row ds-bg-on-${key} ds-fg-${key}-main`}>
+        <span>{label} Contrast Text</span>
+        <code>contrastText</code>
+       </div>
+       <div className={`ds-colour-row ds-bg-${key}-dark ds-fg-${key}-contrast`}>
+        <span>{label} Emphasis</span>
+        <code>dark</code>
+       </div>
+       <div className={`ds-colour-row ds-bg-${key}-light ds-fg-${key}-contrast`}>
+        <span>{label} Accent</span>
+        <code>light</code>
+       </div>
+       <div className={`ds-colour-row ds-bg-${key}-container ds-fg-${key}-on-container`}>
+        <span>{label} Container</span>
+        <code>container</code>
+       </div>
+       <div className={`ds-colour-row ds-bg-${key}-on-container ds-fg-${key}-container`}>
+        <span>{label} On Container</span>
+        <code>onContainer</code>
+       </div>
+       <div className={`ds-colour-row ds-bg-${key}-solid ds-fg-${key}-on-solid`}>
+        <span>{label} Solid</span>
+        <code>solid</code>
+       </div>
+       <div className={`ds-colour-row ds-bg-${key}-on-solid ds-fg-${key}-solid`}>
+        <span>{label} On Solid</span>
+        <code>onSolid</code>
+       </div>
+      </div>
+      {hasFixed && (
+       <div className="ds-colour-stack ds-colour-stack-fixed">
+        <div className={`ds-colour-row ds-bg-${key}-fixed ds-fg-${key}-on-fixed`}>
+         <span>{label} Fixed</span>
+         <code>fixed</code>
+        </div>
+        <div className={`ds-colour-row ds-bg-${key}-fixed-dim ds-fg-${key}-on-fixed`}>
+         <span>{label} Fixed Dim</span>
+         <code>fixedDim</code>
+        </div>
+        <div className={`ds-colour-row ds-bg-${key}-on-fixed ds-fg-${key}-fixed`}>
+         <span>{label} On Fixed</span>
+         <code>onFixed</code>
+        </div>
+       </div>
+      )}
+     </div>
+    ))}
+
+   </div>
+  </section>
+  <section>
+   <h3>Core brand colours</h3>
+   <p>
+    <code>Brand</code> is exposed as a MUI palette role. <code>Tertiary</code>{" "}
+    and <code>Highlight</code> are available as token families via CSS
+    variables, but are not currently exposed as MUI palette roles.
+   </p>
+   <div className="ds-intent-grid">
+    {[
+     ["brand", "Brand", true],
+     ["tertiary", "Tertiary", false],
+     ["highlight", "Highlight", false],
+    ].map(([key, label, hasFixed]) => (
+     <div className="ds-colour-family" key={key}>
+      <div className="ds-colour-stack">
+       <div className={`ds-colour-row ds-bg-${key}-main ds-fg-${key}-contrast`}>
+        <span>{label}</span>
+        <code>main</code>
+       </div>
+       <div className={`ds-colour-row ds-bg-on-${key} ds-fg-${key}-main`}>
+        <span>{label} Contrast Text</span>
+        <code>contrastText</code>
        </div>
        <div className={`ds-colour-row ds-bg-${key}-dark ds-fg-${key}-contrast`}>
         <span>{label} Emphasis</span>
@@ -90,60 +165,60 @@ This page is a token reference. If you're deciding which colour role to use, rea
     <div className="ds-colour-stack">
      <div className="ds-colour-row ds-bg-background ds-fg-primary">
       <span>Background</span>
-      <code>background</code>
+      <code>background.default</code>
      </div>
      <div className="ds-colour-row ds-bg-surface ds-fg-primary">
       <span>Surface</span>
-      <code>surface</code>
+      <code>background.paper</code>
      </div>
      <div className="ds-colour-row ds-bg-surface-container ds-fg-primary">
       <span>Surface Container</span>
-      <code>surface.container</code>
+      <code>surface.subtle</code>
      </div>
      <div className="ds-colour-row ds-bg-surface-container-high ds-fg-primary">
       <span>Surface Container High</span>
-      <code>surface.containerHigh</code>
+      <code>surface.strong</code>
      </div>
      <div className="ds-colour-row ds-bg-surface-disabled ds-fg-on-surface-disabled">
       <span>Surface Disabled</span>
-      <code>surface.disabled</code>
+      <code>action.disabledBackground</code>
      </div>
     </div>
     <div className="ds-colour-stack">
      <div className="ds-colour-row ds-bg-on-surface ds-fg-surface">
       <span>On Surface</span>
-      <code>onSurface</code>
+      <code>text.primary</code>
      </div>
      <div className="ds-colour-row ds-bg-on-surface-variant ds-fg-surface">
       <span>On Surface Variant</span>
-      <code>onSurfaceVariant</code>
+      <code>text.secondary</code>
      </div>
      <div className="ds-colour-row ds-bg-on-surface-subtle ds-fg-surface">
       <span>On Surface Subtle</span>
-      <code>onSurfaceSubtle</code>
+      <code>text.tertiary</code>
      </div>
      <div className="ds-colour-row ds-bg-on-surface-muted ds-fg-surface">
       <span>On Surface Muted</span>
-      <code>onSurfaceMuted</code>
+      <code>text.muted</code>
      </div>
      <div className="ds-colour-row ds-bg-action-disabled ds-fg-surface">
       <span>Action Disabled</span>
-      <code>action.disabled</code>
+      <code>--ds-action-disabled</code>
      </div>
     </div>
     <div className="ds-colour-family">
      <div className="ds-colour-stack">
       <div className="ds-colour-row ds-bg-placeholder ds-fg-surface">
        <span>Placeholder</span>
-       <code>placeholder</code>
+       <code>text.placeholder</code>
       </div>
      <div className="ds-colour-row ds-bg-placeholder-focus ds-fg-surface">
        <span>Placeholder Focus</span>
-       <code>placeholder.focus</code>
+       <code>text.placeholderFocus</code>
       </div>
      <div className="ds-colour-row ds-bg-on-solid ds-fg-primary">
        <span>On Solid</span>
-       <code>onSolid</code>
+       <code>text.onSolid</code>
       </div>
      </div>
      <div className="ds-colour-stack ds-colour-stack-fixed">
@@ -170,22 +245,99 @@ This page is a token reference. If you're deciding which colour role to use, rea
  <section className="ds-mode-panel" data-mode="dark">
   <section>
    <h3>Intent colours</h3>
+   <p>
+    Exposed as MUI palette roles (e.g. <code>theme.palette.primary.main</code>
+    ).
+   </p>
    <div className="ds-intent-grid">
     {[
      ["primary", "Primary", false],
      ["secondary", "Secondary", false],
-     ["tertiary", "Tertiary", false],
-     ["brand", "Brand", true],
+     ["info", "Info", false],
      ["danger", "Danger", false],
      ["warning", "Warning", false],
      ["success", "Success", false],
-     ["info", "Info", false],
     ].map(([key, label, hasFixed]) => (
      <div className="ds-colour-family" key={key}>
       <div className="ds-colour-stack">
        <div className={`ds-colour-row ds-bg-${key}-main ds-fg-${key}-contrast`}>
         <span>{label}</span>
         <code>main</code>
+       </div>
+       <div className={`ds-colour-row ds-bg-on-${key} ds-fg-${key}-main`}>
+        <span>{label} Contrast Text</span>
+        <code>contrastText</code>
+       </div>
+       <div className={`ds-colour-row ds-bg-${key}-dark ds-fg-${key}-contrast`}>
+        <span>{label} Emphasis</span>
+        <code>dark</code>
+       </div>
+       <div className={`ds-colour-row ds-bg-${key}-light ds-fg-${key}-contrast`}>
+        <span>{label} Accent</span>
+        <code>light</code>
+       </div>
+       <div className={`ds-colour-row ds-bg-${key}-container ds-fg-${key}-on-container`}>
+        <span>{label} Container</span>
+        <code>container</code>
+       </div>
+       <div className={`ds-colour-row ds-bg-${key}-on-container ds-fg-${key}-container`}>
+        <span>{label} On Container</span>
+        <code>onContainer</code>
+       </div>
+       <div className={`ds-colour-row ds-bg-${key}-solid ds-fg-${key}-on-solid`}>
+        <span>{label} Solid</span>
+        <code>solid</code>
+       </div>
+       <div className={`ds-colour-row ds-bg-${key}-on-solid ds-fg-${key}-solid`}>
+        <span>{label} On Solid</span>
+        <code>onSolid</code>
+       </div>
+      </div>
+      {hasFixed && (
+       <div className="ds-colour-stack ds-colour-stack-fixed">
+        <div className={`ds-colour-row ds-bg-${key}-fixed ds-fg-${key}-on-fixed`}>
+         <span>{label} Fixed</span>
+         <code>fixed</code>
+        </div>
+
+        <div className={`ds-colour-row ds-bg-${key}-fixed-dim ds-fg-${key}-on-fixed`}>
+         <span>{label} Fixed Dim</span>
+         <code>fixedDim</code>
+        </div>
+
+        <div className={`ds-colour-row ds-bg-${key}-on-fixed ds-fg-${key}-fixed`}>
+         <span>{label} On Fixed</span>
+         <code>onFixed</code>
+        </div>
+       </div>
+      )}
+     </div>
+    ))}
+
+   </div>
+  </section>
+  <section>
+   <h3>Core brand colours</h3>
+   <p>
+    <code>Brand</code> is exposed as a MUI palette role. <code>Tertiary</code>{" "}
+    and <code>Highlight</code> are available as token families via CSS
+    variables, but are not currently exposed as MUI palette roles.
+   </p>
+   <div className="ds-intent-grid">
+    {[
+     ["brand", "Brand", true],
+     ["tertiary", "Tertiary", false],
+     ["highlight", "Highlight", false],
+    ].map(([key, label, hasFixed]) => (
+     <div className="ds-colour-family" key={key}>
+      <div className="ds-colour-stack">
+       <div className={`ds-colour-row ds-bg-${key}-main ds-fg-${key}-contrast`}>
+        <span>{label}</span>
+        <code>main</code>
+       </div>
+       <div className={`ds-colour-row ds-bg-on-${key} ds-fg-${key}-main`}>
+        <span>{label} Contrast Text</span>
+        <code>contrastText</code>
        </div>
        <div className={`ds-colour-row ds-bg-${key}-dark ds-fg-${key}-contrast`}>
         <span>{label} Emphasis</span>
@@ -241,60 +393,60 @@ This page is a token reference. If you're deciding which colour role to use, rea
     <div className="ds-colour-stack">
      <div className="ds-colour-row ds-bg-background ds-fg-primary">
       <span>Background</span>
-      <code>background</code>
+      <code>background.default</code>
      </div>
      <div className="ds-colour-row ds-bg-surface ds-fg-primary">
       <span>Surface</span>
-      <code>surface</code>
+      <code>background.paper</code>
      </div>
      <div className="ds-colour-row ds-bg-surface-container ds-fg-primary">
       <span>Surface Container</span>
-      <code>surface.container</code>
+      <code>surface.subtle</code>
      </div>
      <div className="ds-colour-row ds-bg-surface-container-high ds-fg-primary">
       <span>Surface Container High</span>
-      <code>surface.containerHigh</code>
+      <code>surface.strong</code>
      </div>
      <div className="ds-colour-row ds-bg-surface-disabled ds-fg-on-surface-disabled">
       <span>Surface Disabled</span>
-      <code>surface.disabled</code>
+      <code>action.disabledBackground</code>
      </div>
     </div>
     <div className="ds-colour-stack">
      <div className="ds-colour-row ds-bg-on-surface ds-fg-surface">
       <span>On Surface</span>
-      <code>onSurface</code>
+      <code>text.primary</code>
      </div>
      <div className="ds-colour-row ds-bg-on-surface-variant ds-fg-surface">
       <span>On Surface Variant</span>
-      <code>onSurfaceVariant</code>
+      <code>text.secondary</code>
      </div>
      <div className="ds-colour-row ds-bg-on-surface-subtle ds-fg-surface">
       <span>On Surface Subtle</span>
-      <code>onSurfaceSubtle</code>
+      <code>text.tertiary</code>
      </div>
      <div className="ds-colour-row ds-bg-on-surface-muted ds-fg-surface">
       <span>On Surface Muted</span>
-      <code>onSurfaceMuted</code>
+      <code>text.muted</code>
      </div>
      <div className="ds-colour-row ds-bg-action-disabled ds-fg-surface">
       <span>Action Disabled</span>
-      <code>action.disabled</code>
+      <code>--ds-action-disabled</code>
      </div>
     </div>
     <div className="ds-colour-family">
      <div className="ds-colour-stack">
       <div className="ds-colour-row ds-bg-placeholder ds-fg-surface">
        <span>Placeholder</span>
-       <code>placeholder</code>
+       <code>text.placeholder</code>
       </div>
       <div className="ds-colour-row ds-bg-placeholder-focus ds-fg-surface">
        <span>Placeholder Focus</span>
-       <code>placeholder.focus</code>
+       <code>text.placeholderFocus</code>
       </div>
       <div className="ds-colour-row ds-bg-on-solid ds-fg-surface">
        <span>On Solid</span>
-       <code>onSolid</code>
+       <code>text.onSolid</code>
       </div>
      </div>
      <div className="ds-colour-stack ds-colour-stack-fixed">


### PR DESCRIPTION
Correct MUI role calls, regroup and introduce brand colours

- Corrected mislabeled MUI palette calls in the Neutral colours reference (e.g. `onSurfaceMuted` → `text.muted`) to match the real roles in DiamondDSTheme.ts.
- Split "Intent colours" into two groups: functional MUI-exposed roles (primary, secondary, info, danger, warning, success) and a new "Core brand colours" section (brand, tertiary, highlight). _Only brand is still an actual MUI palette role._ 
- Added a contrastText row to each intent/brand family, previously undocumented.


p.s. We can name Tertiary to something else like **Brand Accent** if we thing it would be helpful
