### PR TITLE
Rework Navbar surface options and fix logo tone matching

### DIFF
--- a/src/components/controls/Bar.stories.tsx
+++ b/src/components/controls/Bar.stories.tsx
@@ -7,6 +7,21 @@ const meta: Meta<BarSlotsProps> = {
   component: Bar,
   tags: ["autodocs"],
 
+  parameters: {
+    docs: {
+      description: {
+        component: `Basic bar. Comes with three slots, and adjustable width. Children are placed in the left slot.
+
+\`surface\` picks the background family; \`variant\` picks how saturated it is within that family.
+
+- \`primary\` / \`secondary\` / \`brand\` — semantic intents. Only \`solid\`/\`container\` actually use the intent colour; \`base\` falls back to a plain neutral background.
+- \`brand-fixed\` / \`brand-fixedDim\` — a persistent Diamond identity colour that stays constant across light/dark mode, unlike \`brand\`. \`variant\` is ignored.
+- \`surface\` / \`paper\` — neutral, non-branded surface (aliases of each other).
+- \`background\` — the page's own background colour. \`variant\` is ignored.`,
+      },
+    },
+  },
+
   argTypes: {
     surface: {
       control: "select",
@@ -27,7 +42,7 @@ const meta: Meta<BarSlotsProps> = {
       options: ["base", "container", "solid"],
       if: { arg: "surface", neq: ["background"] },
       description:
-        "Use 'base' only with surface/paper. Use 'container' or 'solid' for primary, secondary, and brand.",
+        "'base' renders a plain neutral background — it does not tint primary/secondary/brand, so use 'container' or 'solid' there for the intent colour to actually show.",
       table: { category: "Appearance" },
     },
     elevation: {
@@ -164,7 +179,7 @@ export const PrimaryVsSurface: Story = {
     docs: {
       description: {
         story:
-          "Semantic surfaces (e.g. primary, secondary) express intent, while neutral surfaces define structure and hierarchy.",
+          "Semantic surfaces (e.g. primary, secondary) express intent, while neutral surfaces define structure and hierarchy. Note this only holds for 'solid'/'container' — a semantic surface with variant='base' falls back to the same plain neutral shown here, not the intent colour.",
       },
     },
   },
@@ -199,7 +214,8 @@ export const ActionVariants: Story = {
   parameters: {
     docs: {
       description: {
-        story: "Variants adjust emphasis.",
+        story:
+          "'solid' and 'container' adjust emphasis on a semantic surface. 'base' is left out here deliberately — on primary/secondary/brand it doesn't tint at all, it falls back to a plain neutral background.",
       },
     },
   },
@@ -232,7 +248,7 @@ export const BrandOptions: Story = {
     docs: {
       description: {
         story:
-          "Brand surfaces are used for identity. brand-fixed and brand-fixedDim ignore variant prop and remain consistent across dark/light modes.",
+          "Brand surfaces are used for identity. brand-fixed and brand-fixedDim ignore the variant prop and stay a constant colour across light/dark mode, unlike brand (solid/container), which adapts with the theme.",
       },
     },
   },

--- a/src/components/controls/Bar.test.tsx
+++ b/src/components/controls/Bar.test.tsx
@@ -25,6 +25,13 @@ describe("Bar", () => {
     expect(await screen.findByTestId("test-right-slot")).toBeInTheDocument();
   });
 
+  it("should have a 48px minimum height", async () => {
+    renderWithProviders(<Bar data-testid="test-bar" />);
+
+    const bar = await screen.findByTestId("test-bar");
+    expect(window.getComputedStyle(bar).minHeight).toBe("48px");
+  });
+
   it("should render with styles", async () => {
     const borderStyle = "1px solid rgb(255, 165, 0)";
     renderWithProviders(
@@ -37,8 +44,6 @@ describe("Bar", () => {
     const headerComputedStyle = window.getComputedStyle(bar);
     // check new style is set
     expect(headerComputedStyle.border).toBe(borderStyle);
-    // Check default values are still set
-    expect(headerComputedStyle.height).not.toBe("0px");
   });
 });
 

--- a/src/components/controls/Bar.tsx
+++ b/src/components/controls/Bar.tsx
@@ -150,7 +150,7 @@ const BoxStyled = styled(Box)<BarProps>(({ theme, ...ownerState }) => {
 
   return {
     width: "100%",
-    minHeight: 50,
+    minHeight: 48,
     display: "flex",
     alignItems: "center",
     backgroundColor,

--- a/src/components/controls/Bar.tsx
+++ b/src/components/controls/Bar.tsx
@@ -11,6 +11,18 @@ import { Theme } from "@mui/material/styles";
 
 type BarProps = BoxProps & {
   containerWidth?: false | Breakpoint;
+
+  /**
+   * Background family for the bar. Pairs with `variant` — see its doc for how each surface
+   * responds to `solid` / `container` / `base`.
+   *
+   * - `primary` / `secondary` / `brand` — semantic intents. Only `solid`/`container` actually use
+   *   the intent colour; `base` falls back to a plain neutral background.
+   * - `brand-fixed` / `brand-fixedDim` — a persistent Diamond identity colour that stays constant
+   *   across light/dark mode, unlike `brand`. `variant` is ignored.
+   * - `surface` / `paper` — neutral, non-branded surface (aliases of each other).
+   * - `background` — the page's own background colour. `variant` is ignored.
+   */
   surface?:
     | "primary"
     | "secondary"
@@ -21,6 +33,16 @@ type BarProps = BoxProps & {
     | "paper"
     | "background";
 
+  /**
+   * How saturated the chosen `surface` is.
+   *
+   * - `solid` — full intent colour on a semantic surface, or the strongest neutral on `surface`/`paper`.
+   * - `container` — tinted container colour on a semantic surface, or a subtle neutral tint on `surface`/`paper`.
+   * - `base` (default) — plain neutral background. On a semantic surface (`primary`/`secondary`/`brand`)
+   *   this does NOT apply the intent colour — it renders the same neutral background as `surface`/`base`.
+   *
+   * Ignored by `brand-fixed`, `brand-fixedDim`, and `background`.
+   */
   variant?: "solid" | "container" | "base";
   elevation?: number;
 };

--- a/src/components/navigation/Footer.test.tsx
+++ b/src/components/navigation/Footer.test.tsx
@@ -33,9 +33,6 @@ describe("Footer logo and copyright", () => {
 
     // check new style is set
     expect(footerComputedStyle.border).toBe(borderStyle);
-
-    // Check default values are still set
-    expect(footerComputedStyle.minHeight).toBe("50px");
   });
 
   test("Should render logo only", async () => {

--- a/src/components/navigation/Navbar.stories.tsx
+++ b/src/components/navigation/Navbar.stories.tsx
@@ -16,6 +16,23 @@ const meta: Meta<typeof Navbar> = {
   component: Navbar,
   subcomponents: { NavMenu, NavMenuLink, NavLink, NavLinks },
   tags: ["autodocs"],
+
+  parameters: {
+    docs: {
+      description: {
+        component: `Basic navigation bar. Can be used with \`NavLinks\` and \`NavLink\` to display a responsive list of links.
+
+- \`brand\` (default) — solid brand colour that adapts with light/dark mode.
+- \`brand-fixed\` / \`brand-fixedDim\` — a persistent Diamond identity colour that stays constant across modes.
+- \`surface\` \`base\` — plain neutral background.
+- \`surface\` \`container\` — a subtle neutral tint.
+
+Most Diamond apps should probably reach for \`brand-fixed\` or \`surface\`/\`base\` rather than the default — a constant Diamond identity colour, or a plain neutral bar, tends to suit real product chrome better than a navbar that shifts with the mode.
+
+\`brand-fixed\`/\`brand-fixedDim\` (any variant) and \`solid\` variant on \`brand\`/\`primary\`/\`secondary\` resolve to a fully saturated colour that provides its own separation from the page. Every other combination — including \`container\`, and \`base\` on a semantic intent, which falls back to a plain neutral background — picks up a bottom border so it doesn't blend into the content below.`,
+      },
+    },
+  },
 };
 
 export default meta;
@@ -67,21 +84,20 @@ export const All: Story = {
 export const NavbarVariants: Story = {
   render: (_args) => (
     <>
-      <Navbar leftSlot={<Typography>Default (brand-fixed)</Typography>} />
+      <Navbar leftSlot={<Typography>Default (brand)</Typography>} />
       <Navbar
-        surface="brand"
-        variant="solid"
-        leftSlot={<Typography>Brand Solid</Typography>}
-      />
-      <Navbar
-        surface="primary"
-        variant="container"
-        leftSlot={<Typography>Primary Container</Typography>}
+        surface="brand-fixed"
+        leftSlot={<Typography>Brand Fixed</Typography>}
       />
       <Navbar
         surface="surface"
-        elevation={2}
-        leftSlot={<Typography>Surface Elevated</Typography>}
+        variant="base"
+        leftSlot={<Typography>Surface Base</Typography>}
+      />
+      <Navbar
+        surface="surface"
+        variant="container"
+        leftSlot={<Typography>Surface Container</Typography>}
       />
     </>
   ),
@@ -89,7 +105,7 @@ export const NavbarVariants: Story = {
     docs: {
       description: {
         story:
-          "Navbar defaults to brand-fixed, but surface, variant, and elevation can be customised.",
+          "Navbar defaults to brand (solid), which adapts with light/dark mode. Alternatives are brand-fixed (a persistent Diamond identity colour that doesn't change with mode), surface base, and surface container — the two surface variants pick up a bottom border since they're too close in tone to the page background to rely on contrast alone. Most Diamond apps should probably reach for brand-fixed or surface base rather than the default.",
       },
     },
   },

--- a/src/components/navigation/Navbar.tsx
+++ b/src/components/navigation/Navbar.tsx
@@ -112,7 +112,19 @@ type NavbarProps = BarSlotsProps & {
 };
 
 /**
- * Basic navigation bar. Can be used with `NavLinks` and `NavLink` to display a responsive list of links. Brand surface by default.
+ * Basic navigation bar. Can be used with `NavLinks` and `NavLink` to display a responsive list of links.
+ *
+ * Defaults to the `brand` surface (solid), which adapts with light/dark mode like the rest of
+ * the theme. Alternatives include `brand-fixed`/`brand-fixedDim` for a persistent Diamond
+ * identity colour that stays constant across modes, and the neutral `surface` in `base` or
+ * `container` variant. Most Diamond apps should probably reach for `brand-fixed` or
+ * `surface`/`base` rather than the default — a constant Diamond identity colour, or a plain
+ * neutral bar, tend to suit real product chrome better than a navbar that shifts with the mode.
+ *
+ * `brand-fixed`/`brand-fixedDim` (any variant) and `solid` variant on `brand`/`primary`/`secondary`
+ * resolve to a fully saturated colour that provides its own separation from the page. Every other
+ * combination (including `container`, and `base` on a semantic intent, which falls back to a
+ * plain neutral background) picks up a bottom border so it doesn't blend into the content below.
  */
 const Navbar = ({
   surface = "brand",
@@ -122,9 +134,18 @@ const Navbar = ({
   linkComponent,
   leftSlot,
   children,
+  sx,
   ...props
 }: NavbarProps) => {
-  const forceOnDarkLogo = surface === "brand" || surface === "brand-fixed";
+  const isFixedBrand =
+    surface === "brand-fixed" || surface === "brand-fixedDim";
+  const isSemanticIntent =
+    surface === "brand" || surface === "primary" || surface === "secondary";
+  const isSolidIntent = isSemanticIntent && variant === "solid";
+  // Solid/fixed surfaces stay a dark, saturated colour in both light and dark mode, so the logo
+  // needs to be forced light-on-dark rather than following the page mode.
+  const isSaturatedSurface = isFixedBrand || isSolidIntent;
+  const hasNeutralSurface = !isSaturatedSurface;
 
   return (
     <Bar
@@ -133,6 +154,12 @@ const Navbar = ({
       variant={variant}
       elevation={elevation}
       data-testid="navbar"
+      sx={[
+        hasNeutralSurface && {
+          borderBottom: "1px solid var(--ds-border-subtle)",
+        },
+        ...(Array.isArray(sx) ? sx : [sx]),
+      ]}
       leftSlot={
         <>
           {logo && (
@@ -168,8 +195,8 @@ const Navbar = ({
                       }}
                     >
                       <Logo
-                        fixedTone={forceOnDarkLogo ? "dark" : undefined}
-                        tone="inverse"
+                        fixedTone={isSaturatedSurface ? "dark" : undefined}
+                        tone="default"
                         short
                       />
                     </Box>
@@ -181,13 +208,16 @@ const Navbar = ({
                       }}
                     >
                       <Logo
-                        fixedTone={forceOnDarkLogo ? "dark" : undefined}
-                        tone="inverse"
+                        fixedTone={isSaturatedSurface ? "dark" : undefined}
+                        tone="default"
                       />
                     </Box>
                   </>
                 ) : (
-                  <ImageColourSchemeSwitch image={logo} />
+                  <ImageColourSchemeSwitch
+                    image={logo}
+                    fixedTone={isSaturatedSurface ? "dark" : undefined}
+                  />
                 )}
               </Box>
             </Link>


### PR DESCRIPTION
- Keep default Navbar surface to `brand` (solid), but with updated label; document `brand-fixed`/`brand-fixedDim` as the alternative for a persistent Diamond identity colour that stays constant across modes
- Add a bottom border to any surface that resolves to a neutral background  (surface/paper/background, and `base` variant on a semantic intent) so it doesn't blend into the content below; saturated surfaces (solid brand/primary/secondary, brand-fixed/brand-fixedDim) provide their own separation
- Fix Navbar logo tone: force the light-on-dark logo only for surfaces that stay saturated in both modes, follow the page mode otherwise (previously hardcoded to "inverse" for every non-brand surface, which put the wrong logo on the new surface base/container options); same fix applied to custom (non-theme) logos
- Document the surface/variant matrix on Bar's props and in both components' Storybook docs
- Updated minimum Navbar to `48px` and added a regression test to `Bar.test.tsx` asserting that change and checking for future ones. Removed regression test to `Footer.test.tsx`.