### PR TITLE
Add afterNavSlot and footerSlot to SidebarNav

### DIFF
--- a/src/components/navigation/SidebarNav.stories.tsx
+++ b/src/components/navigation/SidebarNav.stories.tsx
@@ -1,0 +1,139 @@
+import {
+  Abc,
+  ArrowForward,
+  CorporateFare,
+  GraphicEq,
+  Menu,
+} from "@mui/icons-material";
+import { SidebarNav } from "./SidebarNav";
+import { Meta, StoryObj } from "@storybook/react";
+import React from "react";
+import {
+  AppBar,
+  Box,
+  Divider,
+  IconButton,
+  Toolbar,
+  Typography,
+} from "../MUI/MuiWrapped";
+import { Theme } from "@mui/material/styles";
+import { Logo } from "../controls/Logo";
+import { ColourSchemeButton } from "../controls/ColourSchemeButton";
+
+const meta: Meta<typeof SidebarNav> = {
+  title: "Components/Navigation/SidebarNav",
+  component: SidebarNav,
+  tags: ["autodocs"],
+  parameters: {
+    docs: {
+      pages: {},
+      description: {
+        component: `A collapsing/expanding sidebar for your app's primary navigation. Click on the individual stories to see the examples.`,
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const navigation = [
+  {
+    navItems: [
+      {
+        label: "Setup",
+        icon: <Abc />,
+        linkProps: { href: "#1" },
+      },
+      {
+        label: "Acquisition",
+        icon: <ArrowForward />,
+        linkProps: { href: "#2" },
+      },
+      {
+        label: "Analysis",
+        icon: <GraphicEq />,
+        linkProps: { href: "#3" },
+      },
+    ],
+  },
+  {
+    navItems: [
+      {
+        label: "Organisation",
+        icon: <CorporateFare />,
+        linkProps: { href: "" },
+      },
+    ],
+  },
+];
+
+export const Basic: Story = {
+  args: {
+    navigation,
+    open: true,
+  },
+};
+
+export const WithAppBar: Story = {
+  render: (_args) => {
+    const [open, setOpen] = React.useState(true);
+    return (
+      <Box sx={{ display: "flex" }}>
+        <AppBar
+          position="fixed"
+          // color="inherit"
+          sx={{
+            zIndex: (theme: Theme) => theme.zIndex.drawer + 1,
+          }}
+        >
+          <Toolbar>
+            <IconButton
+              size="large"
+              edge="start"
+              color="inherit"
+              aria-label="menu"
+              sx={{ mr: 2 }}
+              onClick={() => setOpen(!open)}
+            >
+              <Menu />
+            </IconButton>
+
+            <Box sx={{ mr: 2, width: 100 }}>
+              <Logo />
+            </Box>
+
+            <Divider orientation="vertical" variant="middle" flexItem />
+
+            <Typography
+              variant="h6"
+              noWrap
+              component="div"
+              sx={{
+                ml: 1.5,
+                mt: 1.25,
+                mr: 1.25,
+              }}
+            >
+              My app
+            </Typography>
+
+            <Box sx={{ ml: "auto" }}>
+              <ColourSchemeButton />
+            </Box>
+          </Toolbar>
+        </AppBar>
+
+        <SidebarNav navigation={navigation} open={open} />
+      </Box>
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "MUI wants to draw a Drawer above everything, so in this example the AppBar's zIndex is increased.",
+      },
+    },
+  },
+};

--- a/src/components/navigation/SidebarNav.stories.tsx
+++ b/src/components/navigation/SidebarNav.stories.tsx
@@ -19,10 +19,18 @@ import {
 import { Theme } from "@mui/material/styles";
 import { Logo } from "../controls/Logo";
 import { ColourSchemeButton } from "../controls/ColourSchemeButton";
+import { NavLink, MemoryRouter } from "react-router-dom";
 
 const meta: Meta<typeof SidebarNav> = {
   title: "Components/Navigation/SidebarNav",
   component: SidebarNav,
+  decorators: [
+    (Story: Story) => (
+      <MemoryRouter>
+        <Story />
+      </MemoryRouter>
+    ),
+  ],
   tags: ["autodocs"],
   parameters: {
     docs: {
@@ -43,17 +51,17 @@ const navigation = [
       {
         label: "Setup",
         icon: <Abc />,
-        linkProps: { href: "#1" },
+        linkProps: { to: "/1", component: NavLink },
       },
       {
         label: "Acquisition",
         icon: <ArrowForward />,
-        linkProps: { href: "#2" },
+        linkProps: { to: "/2", component: NavLink },
       },
       {
         label: "Analysis",
         icon: <GraphicEq />,
-        linkProps: { href: "#3" },
+        linkProps: { to: "/3", component: NavLink },
       },
     ],
   },
@@ -62,7 +70,7 @@ const navigation = [
       {
         label: "Organisation",
         icon: <CorporateFare />,
-        linkProps: { href: "" },
+        linkProps: { href: "#4" },
       },
     ],
   },
@@ -82,10 +90,13 @@ export const WithAppBar: Story = {
       <Box sx={{ display: "flex" }}>
         <AppBar
           position="fixed"
-          // color="inherit"
+          color="inherit"
           sx={{
             zIndex: (theme: Theme) => theme.zIndex.drawer + 1,
+            borderBottom: "1px solid",
+            borderColor: "divider",
           }}
+          elevation={0}
         >
           <Toolbar>
             <IconButton
@@ -99,8 +110,8 @@ export const WithAppBar: Story = {
               <Menu />
             </IconButton>
 
-            <Box sx={{ mr: 2, width: 100 }}>
-              <Logo />
+            <Box sx={{ mr: 2, mt: 1.5 }}>
+              <Logo sx={{ display: "block" }} />
             </Box>
 
             <Divider orientation="vertical" variant="middle" flexItem />

--- a/src/components/navigation/SidebarNav.stories.tsx
+++ b/src/components/navigation/SidebarNav.stories.tsx
@@ -3,7 +3,9 @@ import {
   ArrowForward,
   CorporateFare,
   GraphicEq,
+  Insights,
   Menu,
+  Schedule,
 } from "@mui/icons-material";
 import { SidebarNav } from "./SidebarNav";
 import { Meta, StoryObj } from "@storybook/react";
@@ -45,7 +47,45 @@ const meta: Meta<typeof SidebarNav> = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-const navigation = [
+const standardLinks = [
+  {
+    navItems: [
+      {
+        label: "Setup",
+        icon: <Abc />,
+        linkProps: { href: "" },
+      },
+      {
+        label: "Acquisition",
+        icon: <ArrowForward />,
+        linkProps: { href: "" },
+        selected: true,
+      },
+      {
+        label: "Analysis",
+        icon: <GraphicEq />,
+        linkProps: { href: "" },
+      },
+    ],
+  },
+];
+
+export const NormalLinks: Story = {
+  args: {
+    navigation: standardLinks,
+    open: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "When using standard links, the caller must handle the selected state and set it to the correct item.",
+      },
+    },
+  },
+};
+
+const reactRouterNavigation = [
   {
     navItems: [
       {
@@ -70,16 +110,77 @@ const navigation = [
       {
         label: "Organisation",
         icon: <CorporateFare />,
-        linkProps: { href: "#4" },
+        linkProps: { to: "/4", component: NavLink },
       },
     ],
   },
 ];
 
-export const Basic: Story = {
+export const RouterLinks: Story = {
   args: {
-    navigation,
+    navigation: reactRouterNavigation,
+    open: false,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: `React Router _NavLinks_ will handle selected state internally.`,
+      },
+    },
+  },
+};
+
+const groupedNavigation = [
+  {
+    navItems: [
+      {
+        label: "Setup",
+        icon: <Abc />,
+        linkProps: { to: "/1", component: NavLink },
+      },
+      {
+        label: "Acquisition",
+        icon: <ArrowForward />,
+        linkProps: { to: "/2", component: NavLink },
+      },
+    ],
+  },
+  {
+    navItems: [
+      {
+        label: "Analysis",
+        icon: <GraphicEq />,
+        linkProps: { to: "/3", component: NavLink },
+      },
+      {
+        label: "Data Browse",
+        icon: <Insights />,
+        linkProps: { to: "/4", component: NavLink },
+      },
+    ],
+  },
+  {
+    navItems: [
+      {
+        label: "Log",
+        icon: <Schedule />,
+        linkProps: { to: "/5", component: NavLink },
+      },
+    ],
+  },
+];
+
+export const GroupedNavigation: Story = {
+  args: {
+    navigation: groupedNavigation,
     open: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "Sections are grouped with dividers",
+      },
+    },
   },
 };
 
@@ -135,7 +236,7 @@ export const WithAppBar: Story = {
           </Toolbar>
         </AppBar>
 
-        <SidebarNav navigation={navigation} open={open} />
+        <SidebarNav navigation={reactRouterNavigation} open={open} />
       </Box>
     );
   },

--- a/src/components/navigation/SidebarNav.stories.tsx
+++ b/src/components/navigation/SidebarNav.stories.tsx
@@ -25,7 +25,7 @@ const meta: Meta<typeof SidebarNav> = {
   title: "Components/Navigation/SidebarNav",
   component: SidebarNav,
   decorators: [
-    (Story: Story) => (
+    (Story) => (
       <MemoryRouter>
         <Story />
       </MemoryRouter>

--- a/src/components/navigation/SidebarNav.stories.tsx
+++ b/src/components/navigation/SidebarNav.stories.tsx
@@ -236,7 +236,15 @@ export const WithAppBar: Story = {
           </Toolbar>
         </AppBar>
 
-        <SidebarNav navigation={reactRouterNavigation} open={open} />
+        <SidebarNav
+          navigation={reactRouterNavigation}
+          open={open}
+          setOpen={setOpen}
+        />
+        <Box>
+          <Toolbar />
+          <Typography variant="h5">Main content here</Typography>
+        </Box>
       </Box>
     );
   },

--- a/src/components/navigation/SidebarNav.test.tsx
+++ b/src/components/navigation/SidebarNav.test.tsx
@@ -9,7 +9,6 @@ vi.mock("@mui/material/useMediaQuery");
 const mockedUseMediaQuery = vi.mocked(useMediaQuery);
 
 describe("SidebarNav", () => {
-
   const navigation: Navigation = [
     {
       navItems: [
@@ -45,14 +44,15 @@ describe("SidebarNav", () => {
     const router = createMemoryRouter([
       {
         path: "/",
-        element: <SidebarNav navigation={navigation} open={open} setOpen={setOpen}/>,
+        element: (
+          <SidebarNav navigation={navigation} open={open} setOpen={setOpen} />
+        ),
       },
     ]);
     render(<RouterProvider router={router} />);
   }
 
   describe("Desktop layout", () => {
-
     beforeEach(() => {
       mockedUseMediaQuery.mockReturnValue(true);
     });
@@ -96,7 +96,9 @@ describe("SidebarNav", () => {
       await user.hover(icon);
 
       // notice we await because the tooltip appears after some time
-      const tooltip = await screen.findByRole("tooltip", { name: "Acquisition" });
+      const tooltip = await screen.findByRole("tooltip", {
+        name: "Acquisition",
+      });
       expect(tooltip).toBeVisible();
     });
 
@@ -133,26 +135,27 @@ describe("SidebarNav", () => {
   });
 
   describe("Mobile layout", () => {
-
     beforeEach(() => {
       mockedUseMediaQuery.mockReturnValue(false);
     });
 
     it("renders temporary drawer", () => {
-        renderSidenav(true);
+      renderSidenav(true);
 
-        // Drawer paper is rendered
-        expect(document.querySelector(".MuiDrawer-root")).toBeInTheDocument();
+      // Drawer paper is rendered
+      expect(document.querySelector(".MuiDrawer-root")).toBeInTheDocument();
 
-        // nav content is visible
-        expect(screen.getByText("Setup")).toBeVisible();
-      });
+      // nav content is visible
+      expect(screen.getByText("Setup")).toBeVisible();
+    });
 
     it("closed drawer is not visible", () => {
       renderSidenav(false);
 
       expect(screen.queryByText("Setup")).not.toBeInTheDocument();
-      expect(screen.queryByRole("link", { name: "Setup" })).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("link", { name: "Setup" }),
+      ).not.toBeInTheDocument();
     });
 
     it("open drawer is visible", () => {

--- a/src/components/navigation/SidebarNav.test.tsx
+++ b/src/components/navigation/SidebarNav.test.tsx
@@ -2,8 +2,14 @@ import { render, screen } from "@testing-library/react";
 import { Navigation, SidebarNav } from "./SidebarNav";
 import { createMemoryRouter, NavLink, RouterProvider } from "react-router-dom";
 import userEvent from "@testing-library/user-event";
+import useMediaQuery from "@mui/material/useMediaQuery";
+
+vi.mock("@mui/material/useMediaQuery");
+
+const mockedUseMediaQuery = vi.mocked(useMediaQuery);
 
 describe("SidebarNav", () => {
+
   const navigation: Navigation = [
     {
       navItems: [
@@ -35,87 +41,151 @@ describe("SidebarNav", () => {
     },
   ];
 
-  function renderSidenav(open: boolean) {
+  function renderSidenav(open: boolean, setOpen = vi.fn()) {
     const router = createMemoryRouter([
       {
         path: "/",
-        element: <SidebarNav navigation={navigation} open={open} />,
+        element: <SidebarNav navigation={navigation} open={open} setOpen={setOpen}/>,
       },
     ]);
     render(<RouterProvider router={router} />);
   }
 
-  it("Shows icons and names when open", () => {
-    renderSidenav(true);
+  describe("Desktop layout", () => {
 
-    const items = navigation[0].navItems;
-
-    items.forEach((item) => {
-      const button = screen.getByRole("link", { name: item.label });
-      expect(button).toBeVisible();
-      const label = screen.getByText(item.label);
-      expect(label).toBeVisible();
+    beforeEach(() => {
+      mockedUseMediaQuery.mockReturnValue(true);
     });
-    ["navicon1", "navicon2", "navicon3", "navicon4"].forEach((id) =>
-      expect(screen.getByTestId(id)).toBeVisible(),
-    );
-  });
 
-  it("Shows icons only when closed", () => {
-    renderSidenav(false);
-    const items = navigation[0].navItems;
-    items.forEach((item) => {
-      const button = screen.getByRole("link", { name: item.label });
-      expect(button).toBeVisible(); // a11y-wise still visible
-      const label = screen.getByText(item.label);
-      expect(label).toBeInTheDocument(); // label exists but
-      expect(label).not.toBeVisible(); // not visible
+    it("Shows icons and names when open", () => {
+      renderSidenav(true);
+
+      const items = navigation[0].navItems;
+
+      items.forEach((item) => {
+        const button = screen.getByRole("link", { name: item.label });
+        expect(button).toBeVisible();
+        const label = screen.getByText(item.label);
+        expect(label).toBeVisible();
+      });
+      ["navicon1", "navicon2", "navicon3", "navicon4"].forEach((id) =>
+        expect(screen.getByTestId(id)).toBeVisible(),
+      );
     });
-    ["navicon1", "navicon2", "navicon3", "navicon4"].forEach((id) =>
-      expect(screen.getByTestId(id)).toBeVisible(),
-    );
-  });
 
-  it("shows tooltip on buttons when closed", async () => {
-    renderSidenav(false);
-
-    const icon = screen.getByTestId("navicon2");
-    const user = userEvent.setup();
-    await user.hover(icon);
-
-    // notice we await because the tooltip appears after some time
-    const tooltip = await screen.findByRole("tooltip", { name: "Acquisition" });
-    expect(tooltip).toBeVisible();
-  });
-
-  it("shows no tooltip on buttons when open", async () => {
-    renderSidenav(true);
-
-    const icon = screen.getByTestId("navicon2");
-    const user = userEvent.setup();
-    await user.hover(icon);
-
-    const tooltip = screen.queryByRole("tooltip", {
-      name: "Acquisition",
+    it("Shows icons only when closed", () => {
+      renderSidenav(false);
+      const items = navigation[0].navItems;
+      items.forEach((item) => {
+        const button = screen.getByRole("link", { name: item.label });
+        expect(button).toBeVisible(); // a11y-wise still visible
+        const label = screen.getByText(item.label);
+        expect(label).toBeInTheDocument(); // label exists but
+        expect(label).not.toBeVisible(); // not visible
+      });
+      ["navicon1", "navicon2", "navicon3", "navicon4"].forEach((id) =>
+        expect(screen.getByTestId(id)).toBeVisible(),
+      );
     });
-    expect(tooltip).not.toBeInTheDocument();
+
+    it("shows tooltip on buttons when closed", async () => {
+      renderSidenav(false);
+
+      const icon = screen.getByTestId("navicon2");
+      const user = userEvent.setup();
+      await user.hover(icon);
+
+      // notice we await because the tooltip appears after some time
+      const tooltip = await screen.findByRole("tooltip", { name: "Acquisition" });
+      expect(tooltip).toBeVisible();
+    });
+
+    it("shows no tooltip on buttons when open", async () => {
+      renderSidenav(true);
+
+      const icon = screen.getByTestId("navicon2");
+      const user = userEvent.setup();
+      await user.hover(icon);
+
+      const tooltip = screen.queryByRole("tooltip", {
+        name: "Acquisition",
+      });
+      expect(tooltip).not.toBeInTheDocument();
+    });
+
+    it("creates divider between nav sections", () => {
+      renderSidenav(true);
+      const divider = screen.queryByRole("separator");
+      expect(divider).toBeInTheDocument();
+    });
+
+    it("renders internal and external links with correct href", () => {
+      // even though specified differently, ultimately both types
+      // should have the correct href attribute
+      renderSidenav(true);
+
+      const externalLink = screen.getByRole("link", { name: "Organisation" });
+      expect(externalLink).toHaveAttribute("href", "https://www.example.com");
+
+      const internalLink = screen.getByRole("link", { name: "Setup" });
+      expect(internalLink).toHaveAttribute("href", "/setup");
+    });
   });
 
-  it("creates divider between nav sections", () => {
-    renderSidenav(true);
-    const divider = screen.queryByRole("separator");
-    expect(divider).toBeInTheDocument();
-  });
+  describe("Mobile layout", () => {
 
-  it("renders internal and external links with correct href", () => {
-    // even though specified differently, ultimately both types
-    // should have the correct href attribute
-    renderSidenav(true);
+    beforeEach(() => {
+      mockedUseMediaQuery.mockReturnValue(false);
+    });
 
-    const externalLink = screen.getByRole("link", { name: "Organisation" });
-    expect(externalLink).toHaveAttribute("href", "https://www.example.com");
+    it("renders temporary drawer", () => {
+        renderSidenav(true);
 
-    const internalLink = screen.getByRole("link", { name: "Setup" });
-    expect(internalLink).toHaveAttribute("href", "/setup");
+        // Drawer paper is rendered
+        expect(document.querySelector(".MuiDrawer-root")).toBeInTheDocument();
+
+        // nav content is visible
+        expect(screen.getByText("Setup")).toBeVisible();
+      });
+
+    it("closed drawer is not visible", () => {
+      renderSidenav(false);
+
+      expect(screen.queryByText("Setup")).not.toBeInTheDocument();
+      expect(screen.queryByRole("link", { name: "Setup" })).not.toBeInTheDocument();
+    });
+
+    it("open drawer is visible", () => {
+      renderSidenav(true);
+
+      expect(screen.getByText("Setup")).toBeVisible();
+      expect(screen.getByTestId("navicon1")).toBeVisible();
+    });
+
+    it("clicking a nav item closes the drawer", async () => {
+      const user = userEvent.setup();
+      const setOpen = vi.fn();
+
+      renderSidenav(true, setOpen);
+
+      await user.click(screen.getByRole("link", { name: "Setup" }));
+
+      expect(setOpen).toHaveBeenCalledWith(false);
+    });
+
+    it("clicking backdrop closes the drawer", async () => {
+      const user = userEvent.setup();
+      const setOpen = vi.fn();
+
+      renderSidenav(true, setOpen);
+
+      // backdrop is rendered by MUI in portal
+      const backdrop = document.querySelector(".MuiBackdrop-root");
+      expect(backdrop).toBeInTheDocument();
+
+      await user.click(backdrop!);
+
+      expect(setOpen).toHaveBeenCalledWith(false);
+    });
   });
 });

--- a/src/components/navigation/SidebarNav.test.tsx
+++ b/src/components/navigation/SidebarNav.test.tsx
@@ -1,0 +1,121 @@
+import { render, screen } from "@testing-library/react";
+import { Navigation, SidebarNav } from "./SidebarNav";
+import { createMemoryRouter, NavLink, RouterProvider } from "react-router-dom";
+import userEvent from "@testing-library/user-event";
+
+describe("SidebarNav", () => {
+  const navigation: Navigation = [
+    {
+      navItems: [
+        {
+          label: "Setup",
+          icon: <div data-testid="navicon1" />,
+          linkProps: { component: NavLink, to: "/setup" },
+        },
+        {
+          label: "Acquisition",
+          icon: <div data-testid="navicon2" />,
+          linkProps: { component: NavLink, to: "/acq" },
+        },
+        {
+          label: "Analysis",
+          icon: <div data-testid="navicon3" />,
+          linkProps: { component: NavLink, to: "/analysis" },
+        },
+      ],
+    },
+    {
+      navItems: [
+        {
+          label: "Organisation",
+          icon: <div data-testid="navicon4" />,
+          linkProps: { href: "https://www.example.com" },
+        },
+      ],
+    },
+  ];
+
+  function renderSidenav(open: boolean) {
+    const router = createMemoryRouter([
+      {
+        path: "/",
+        element: <SidebarNav navigation={navigation} open={open} />,
+      },
+    ]);
+    render(<RouterProvider router={router} />);
+  }
+
+  it("Shows icons and names when open", () => {
+    renderSidenav(true);
+
+    const items = navigation[0].navItems;
+
+    items.forEach((item) => {
+      const button = screen.getByRole("link", { name: item.label });
+      expect(button).toBeVisible();
+      const label = screen.getByText(item.label);
+      expect(label).toBeVisible();
+    });
+    ["navicon1", "navicon2", "navicon3", "navicon4"].forEach((id) =>
+      expect(screen.getByTestId(id)).toBeVisible(),
+    );
+  });
+
+  it("Shows icons only when closed", () => {
+    renderSidenav(false);
+    const items = navigation[0].navItems;
+    items.forEach((item) => {
+      const button = screen.getByRole("link", { name: item.label });
+      expect(button).toBeVisible(); // a11y-wise still visible
+      const label = screen.getByText(item.label);
+      expect(label).toBeInTheDocument(); // label exists but
+      expect(label).not.toBeVisible(); // not visible
+    });
+    ["navicon1", "navicon2", "navicon3", "navicon4"].forEach((id) =>
+      expect(screen.getByTestId(id)).toBeVisible(),
+    );
+  });
+
+  it("shows tooltip on buttons when closed", async () => {
+    renderSidenav(false);
+
+    const icon = screen.getByTestId("navicon2");
+    const user = userEvent.setup();
+    await user.hover(icon);
+
+    // notice we await because the tooltip appears after some time
+    const tooltip = await screen.findByRole("tooltip", { name: "Acquisition" });
+    expect(tooltip).toBeVisible();
+  });
+
+  it("shows no tooltip on buttons when open", async () => {
+    renderSidenav(true);
+
+    const icon = screen.getByTestId("navicon2");
+    const user = userEvent.setup();
+    await user.hover(icon);
+
+    const tooltip = screen.queryByRole("tooltip", {
+      name: "Acquisition",
+    });
+    expect(tooltip).not.toBeInTheDocument();
+  });
+
+  it("creates divider between nav sections", () => {
+    renderSidenav(true);
+    const divider = screen.queryByRole("separator");
+    expect(divider).toBeInTheDocument();
+  });
+
+  it("renders internal and external links with correct href", () => {
+    // even though specified differently, ultimately both types
+    // should have the correct href attribute
+    renderSidenav(true);
+
+    const externalLink = screen.getByRole("link", { name: "Organisation" });
+    expect(externalLink).toHaveAttribute("href", "https://www.example.com");
+
+    const internalLink = screen.getByRole("link", { name: "Setup" });
+    expect(internalLink).toHaveAttribute("href", "/setup");
+  });
+});

--- a/src/components/navigation/SidebarNav.tsx
+++ b/src/components/navigation/SidebarNav.tsx
@@ -1,0 +1,168 @@
+import {
+  Box,
+  Divider,
+  Drawer,
+  List,
+  ListItem,
+  ListItemButton,
+  ListItemIcon,
+  ListItemText,
+  Toolbar,
+  Tooltip,
+  type Theme,
+} from "@mui/material";
+import { Fragment, type ElementType, type ReactNode } from "react";
+
+export type Navigation = NavItemGroup[];
+
+type NavItemGroup = {
+  name?: string;
+  navItems: NavItemDefinition[];
+};
+
+type NavItemDefinition = {
+  label: string;
+  icon: ReactNode;
+  linkProps: LinkProps;
+};
+
+type LinkProps = ExternalLinkProps | InternalLinkProps;
+
+/** For native anchor tags */
+type ExternalLinkProps = {
+  href: string;
+  component?: never;
+  to?: never;
+};
+
+/** For SPA navigation */
+type InternalLinkProps = {
+  component: ElementType;
+  to: string;
+  href?: never;
+};
+
+const drawerTransition = (theme: Theme, opening: boolean) => {
+  return theme.transitions.create("width", {
+    easing: opening
+      ? theme.transitions.easing.easeIn
+      : theme.transitions.easing.easeOut,
+    duration: opening
+      ? theme.transitions.duration.enteringScreen
+      : theme.transitions.duration.leavingScreen,
+  });
+};
+
+type NavProps = {
+  navigation: Navigation;
+  open: boolean;
+};
+
+export function SidebarNav({ navigation, open }: NavProps) {
+  const width = open ? 257 : 65; // 256/64 + 1 pixel for the border
+  return (
+    <Drawer
+      variant="permanent"
+      sx={(theme) => ({
+        width: width,
+        flexShrink: 0,
+        transition: (theme) => drawerTransition(theme, open),
+        [`& .MuiDrawer-paper`]: {
+          width: width,
+          boxSizing: "border-box",
+          transition: drawerTransition(theme, open),
+        },
+      })}
+    >
+      <Toolbar /> {/* spacer equal to the AppBar's height*/}
+      <Box sx={{ overflow: "auto" }}>
+        <List
+          sx={{
+            p: 1,
+            flexDirection: "column",
+          }}
+        >
+          {navigation.map((group, groupIndex) => (
+            <Fragment key={groupIndex}>
+              {groupIndex > 0 && <SectionDivider />}
+              {group.navItems.map((item, itemIndex) => {
+                return (
+                  <NavItem key={itemIndex} definition={item} open={open} />
+                );
+              })}
+            </Fragment>
+          ))}
+        </List>
+      </Box>
+    </Drawer>
+  );
+}
+
+function SectionDivider() {
+  return (
+    <Box sx={{ mb: 0.5 }}>
+      <Divider />
+    </Box>
+  );
+}
+
+interface NavItemProps {
+  definition: NavItemDefinition;
+  open: boolean;
+}
+
+function NavItem(props: NavItemProps) {
+  const item = props.definition;
+  const open = props.open;
+  const icon = (
+    <ListItemIcon
+      sx={{
+        minWidth: 32,
+        width: 32,
+        height: 32,
+        justifyContent: "center",
+        alignItems: "center",
+        color: open ? "text.secondary" : "text.primary",
+      }}
+    >
+      {item.icon}
+    </ListItemIcon>
+  );
+
+  return (
+    <ListItem disablePadding sx={{ mb: 0.5 }}>
+      <ListItemButton
+        {...item.linkProps}
+        sx={{
+          p: 1,
+          borderRadius: 2,
+          "&.active": {
+            bgcolor: "action.selected",
+            color: "primary.onContainer",
+          },
+          gap: 1.5,
+        }}
+        aria-label={item.label}
+      >
+        {open ? (
+          icon
+        ) : (
+          <Tooltip title={item.label} placement="right">
+            {icon}
+          </Tooltip>
+        )}
+        <ListItemText // always render but conditionally hide
+          primary={item.label}
+          sx={{
+            overflow: "hidden",
+            opacity: open ? 1 : 0,
+            transition: (theme) =>
+              theme.transitions.create("opacity", {
+                duration: theme.transitions.duration.shorter,
+              }),
+          }}
+        />
+      </ListItemButton>
+    </ListItem>
+  );
+}

--- a/src/components/navigation/SidebarNav.tsx
+++ b/src/components/navigation/SidebarNav.tsx
@@ -9,9 +9,11 @@ import {
   ListItemText,
   Toolbar,
   Tooltip,
-  type Theme,
 } from "@mui/material";
+import { useTheme, Theme } from "@mui/material/styles";
 import { Fragment, type ElementType, type ReactNode } from "react";
+import useMediaQuery from "@mui/material/useMediaQuery";
+import { useState } from "react";
 
 export type Navigation = NavItemGroup[];
 
@@ -57,49 +59,96 @@ const drawerTransition = (theme: Theme, opening: boolean) => {
 type NavProps = {
   navigation: Navigation;
   open: boolean;
+  setOpen: (open: boolean) => void;
 };
 
-export function SidebarNav({ navigation, open }: NavProps) {
-  const width = open ? 257 : 65; // 256/64 + 1 pixel for the border
+export function SidebarNav(props: NavProps) {
+  const theme = useTheme();
+  const desktopLayout = useMediaQuery(theme.breakpoints.up("sm"));
+
+  if (desktopLayout) {
+    return <PermanentDrawer {...props} />;
+  }
+  return <TemporaryDrawer {...props} />;
+}
+
+/**
+ * Main layout: a permanant-variant drawer
+ * which toggles between full width and slim states.
+ * Pushes main content to the right.
+ */
+function PermanentDrawer(props: NavProps) {
+  const width = props.open ? 257 : 65; // 256/64 + 1 pixel for the border
   return (
     <Drawer
       variant="permanent"
-      sx={(theme) => ({
+      sx={(theme: Theme) => ({
         width: width,
         flexShrink: 0,
-        transition: (theme) => drawerTransition(theme, open),
+        transition: (theme: Theme) => drawerTransition(theme, props.open),
         [`& .MuiDrawer-paper`]: {
           width: width,
           boxSizing: "border-box",
-          transition: drawerTransition(theme, open),
+          transition: drawerTransition(theme, props.open),
         },
       })}
     >
       <Toolbar /> {/* spacer equal to the AppBar's height*/}
-      <Box sx={{ overflow: "auto" }}>
-        <List
-          sx={{
-            p: 1,
-            flexDirection: "column",
-          }}
-        >
-          {navigation.map((group, groupIndex) => (
-            <Fragment key={groupIndex}>
-              {groupIndex > 0 && <SectionDivider />}
-              {group.navItems.map((item, itemIndex) => {
-                return (
-                  <NavItem
-                    key={itemIndex}
-                    definition={item}
-                    sidebarOpen={open}
-                  />
-                );
-              })}
-            </Fragment>
-          ))}
-        </List>
-      </Box>
+      <NavigationItems {...props} />
     </Drawer>
+  );
+}
+
+/**
+ * Small-screen layout: a temporary drawer which toggles between
+ * not visible and something resembling the full-width variant of the main layout.
+ * Overlayed over main content.
+ */
+function TemporaryDrawer(props: NavProps) {
+  const width = 257;
+  return (
+    <Drawer
+      variant="temporary"
+      open={props.open}
+      onClose={() => props.setOpen(false)}
+      onClick={() => props.setOpen(false)}
+      sx={{
+        width: width,
+        flexShrink: 0,
+        [`& .MuiDrawer-paper`]: {
+          width: width,
+          boxSizing: "border-box",
+          backgroundImage: 'none',
+        },
+      }}
+    >
+      <Toolbar />
+      <NavigationItems {...props} />
+    </Drawer>
+  );
+}
+
+function NavigationItems({ navigation, open }: NavProps) {
+  return (
+    <Box sx={{ overflow: "auto" }}>
+      <List
+        sx={{
+          p: 1,
+          flexDirection: "column",
+        }}
+      >
+        {navigation.map((group, groupIndex) => (
+          <Fragment key={groupIndex}>
+            {groupIndex > 0 && <SectionDivider />}
+            {group.navItems.map((item, itemIndex) => {
+              return (
+                <NavItem key={itemIndex} definition={item} sidebarOpen={open} />
+              );
+            })}
+          </Fragment>
+        ))}
+      </List>
+    </Box>
   );
 }
 
@@ -162,7 +211,7 @@ function NavItem(props: NavItemProps) {
           sx={{
             overflow: "hidden",
             opacity: open ? 1 : 0,
-            transition: (theme) =>
+            transition: (theme: Theme) =>
               theme.transitions.create("opacity", {
                 duration: theme.transitions.duration.shorter,
               }),

--- a/src/components/navigation/SidebarNav.tsx
+++ b/src/components/navigation/SidebarNav.tsx
@@ -13,7 +13,6 @@ import {
 import { useTheme, Theme } from "@mui/material/styles";
 import { Fragment, type ElementType, type ReactNode } from "react";
 import useMediaQuery from "@mui/material/useMediaQuery";
-import { useState } from "react";
 
 export type Navigation = NavItemGroup[];
 
@@ -110,15 +109,17 @@ function TemporaryDrawer(props: NavProps) {
     <Drawer
       variant="temporary"
       open={props.open}
-      onClose={() => props.setOpen(false)}
-      onClick={() => props.setOpen(false)}
+      onClose={() => props.setOpen(false)} // close when clicking off the drawer
+      onClick={() => props.setOpen(false)} // close after making a selection
       sx={{
         width: width,
         flexShrink: 0,
         [`& .MuiDrawer-paper`]: {
           width: width,
           boxSizing: "border-box",
-          backgroundImage: 'none',
+          backgroundImage: "none",
+          borderRight: "1px solid",
+          borderColor: "divider",
         },
       }}
     >

--- a/src/components/navigation/SidebarNav.tsx
+++ b/src/components/navigation/SidebarNav.tsx
@@ -24,6 +24,7 @@ type NavItemDefinition = {
   label: string;
   icon: ReactNode;
   linkProps: LinkProps;
+  selected?: boolean;
 };
 
 type LinkProps = ExternalLinkProps | InternalLinkProps;
@@ -87,7 +88,11 @@ export function SidebarNav({ navigation, open }: NavProps) {
               {groupIndex > 0 && <SectionDivider />}
               {group.navItems.map((item, itemIndex) => {
                 return (
-                  <NavItem key={itemIndex} definition={item} open={open} />
+                  <NavItem
+                    key={itemIndex}
+                    definition={item}
+                    sidebarOpen={open}
+                  />
                 );
               })}
             </Fragment>
@@ -108,12 +113,12 @@ function SectionDivider() {
 
 interface NavItemProps {
   definition: NavItemDefinition;
-  open: boolean;
+  sidebarOpen: boolean;
 }
 
 function NavItem(props: NavItemProps) {
   const item = props.definition;
-  const open = props.open;
+  const open = props.sidebarOpen;
   const icon = (
     <ListItemIcon
       sx={{
@@ -133,10 +138,11 @@ function NavItem(props: NavItemProps) {
     <ListItem disablePadding sx={{ mb: 0.5 }}>
       <ListItemButton
         {...item.linkProps}
+        selected={props.definition.selected}
         sx={{
           p: 1,
           borderRadius: 2,
-          "&.active": {
+          "&.active, &.Mui-selected": {
             bgcolor: "action.selected",
             color: "primary.onContainer",
           },

--- a/src/components/navigation/SidebarNavDocs.mdx
+++ b/src/components/navigation/SidebarNavDocs.mdx
@@ -1,0 +1,7 @@
+import { Canvas, Meta } from '@storybook/addon-docs/blocks';
+import * as SidebarNavStories from "./SidebarNav.stories"
+
+<Meta title="Sidebar Nav documentation" of={SidebarNavStories} />
+
+<Canvas of={SidebarNavStories.WithAppBar} />
+

--- a/src/components/navigation/SidebarNavDocs.mdx
+++ b/src/components/navigation/SidebarNavDocs.mdx
@@ -1,7 +1,0 @@
-import { Canvas, Meta } from '@storybook/addon-docs/blocks';
-import * as SidebarNavStories from "./SidebarNav.stories"
-
-<Meta title="Sidebar Nav documentation" of={SidebarNavStories} />
-
-<Canvas of={SidebarNavStories.WithAppBar} />
-


### PR DESCRIPTION
This is built on top of #221 

- Lets callers inject content after the nav items (inside the scrollable area) or pinned to the bottom of the drawer, e.g. secondary links or a settings/user menu
- Also fixes long labels like "Data Browse" wrapping to two lines and inflating row height while the sidebar is collapsed.

