### PR TITLE
Add increment/decrement spinner buttons to NumberInput

### DIFF
--- a/src/components/controls/NumberInput.stories.tsx
+++ b/src/components/controls/NumberInput.stories.tsx
@@ -13,6 +13,21 @@ const meta: Meta<typeof NumberInput> = {
       },
     },
   },
+  argTypes: {
+    spinnerButtons: {
+      control: "select",
+      options: ["always", "onHover", "never"],
+      description:
+        "Controls visibility of the increment/decrement buttons. Defaults to 'onHover', except for numberMode='scientific' which defaults to 'never'.",
+      table: { category: "Behaviour" },
+    },
+    step: {
+      control: "number",
+      description:
+        "Amount the increment/decrement buttons change the value by.",
+      table: { category: "Behaviour" },
+    },
+  },
 };
 
 export default meta;

--- a/src/components/controls/NumberInput.test.tsx
+++ b/src/components/controls/NumberInput.test.tsx
@@ -158,4 +158,18 @@ describe("NumberInput", () => {
     fireEvent.change(numberInput, { target: { value: "5e5" } });
     expect(screen.queryByText("Invalid input")).not.toBeInTheDocument();
   });
+
+  it("does not accumulate floating point error when stepping", async () => {
+    render(
+      <NumberInput
+        label="numberbox"
+        numberMode="floating"
+        defaultValue={4.1}
+      />,
+    );
+    const numberInput = screen.getByLabelText("numberbox") as HTMLInputElement;
+    const decreaseButton = screen.getByLabelText("Decrease value");
+    fireEvent.click(decreaseButton);
+    expect(numberInput.value).toBe("3.1");
+  });
 });

--- a/src/components/controls/NumberInput.tsx
+++ b/src/components/controls/NumberInput.tsx
@@ -1,5 +1,7 @@
 import React, { useState } from "react";
-import { TextField } from "@mui/material";
+import { Button, ButtonGroup, InputAdornment, TextField } from "@mui/material";
+import KeyboardArrowUpIcon from "@mui/icons-material/KeyboardArrowUp";
+import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
 
 const Modes = {
   /** Natural numbers from 0 to inf */
@@ -27,6 +29,8 @@ interface NumberInputTextProps {
   helperText?: boolean;
   minValue: number;
   maxValue: number;
+  step: number;
+  spinnerButtons: "always" | "onHover" | "never";
 }
 
 const NumberInputText: React.FC<NumberInputTextProps> = ({
@@ -42,7 +46,10 @@ const NumberInputText: React.FC<NumberInputTextProps> = ({
   helperText,
   minValue,
   maxValue,
+  step,
+  spinnerButtons,
 }) => {
+  const showSpinner = spinnerButtons !== "never";
   const validHelperText = !helperText
     ? ""
     : `A ${numberMode} number. Limits: ${minValue} to ${maxValue}`;
@@ -78,6 +85,13 @@ const NumberInputText: React.FC<NumberInputTextProps> = ({
     }
   };
 
+  const handleStep = (direction: 1 | -1) => {
+    const current = isValid && numberText !== "" ? parseFloat(numberText) : 0;
+    const stepped = current + direction * step;
+    const clamped = Math.min(maxValue, Math.max(minValue, stepped));
+    setNumberText(clamped.toString());
+  };
+
   return (
     <TextField
       label={label}
@@ -90,6 +104,61 @@ const NumberInputText: React.FC<NumberInputTextProps> = ({
       error={!isValid || !isInLimits}
       helperText={calculateHelperText()}
       variant="outlined"
+      sx={{
+        ...(showSpinner && {
+          "& .MuiOutlinedInput-root": { paddingRight: "6px" },
+        }),
+        ...(spinnerButtons === "onHover" && {
+          "& .NumberInput-spinner": { opacity: 0 },
+          "&:hover .NumberInput-spinner, &:focus-within .NumberInput-spinner": {
+            opacity: 1,
+          },
+        }),
+      }}
+      slotProps={{
+        input: {
+          endAdornment: showSpinner ? (
+            <InputAdornment
+              position="end"
+              className="NumberInput-spinner"
+              sx={{
+                marginLeft: "6px",
+                marginRight: 0,
+                marginTop: "6px",
+                marginBottom: "6px",
+                height: "auto",
+                maxHeight: "none",
+                alignSelf: "stretch",
+                alignItems: "stretch",
+              }}
+            >
+              <ButtonGroup
+                orientation="vertical"
+                size="small"
+                color="inherit"
+                sx={{ height: "100%" }}
+              >
+                <Button
+                  aria-label="Increase value"
+                  onClick={() => handleStep(1)}
+                  disabled={isInLimits && parseFloat(numberText) >= maxValue}
+                  sx={{ flex: 1, minWidth: 0, minHeight: 0, px: 0.5, py: 0 }}
+                >
+                  <KeyboardArrowUpIcon sx={{ fontSize: 12 }} />
+                </Button>
+                <Button
+                  aria-label="Decrease value"
+                  onClick={() => handleStep(-1)}
+                  disabled={isInLimits && parseFloat(numberText) <= minValue}
+                  sx={{ flex: 1, minWidth: 0, minHeight: 0, px: 0.5, py: 0 }}
+                >
+                  <KeyboardArrowDownIcon sx={{ fontSize: 12 }} />
+                </Button>
+              </ButtonGroup>
+            </InputAdornment>
+          ) : undefined,
+        },
+      }}
     />
   );
 };
@@ -106,6 +175,8 @@ interface NumberInputProps {
   helperText?: boolean;
   minValue?: number;
   maxValue?: number;
+  step?: number;
+  spinnerButtons?: "always" | "onHover" | "never";
 }
 
 const NumberInput: React.FC<NumberInputProps> = ({
@@ -118,6 +189,8 @@ const NumberInput: React.FC<NumberInputProps> = ({
   helperText = true,
   minValue = numberMode == "natural" ? 0 : -Infinity,
   maxValue = Infinity,
+  step = 1,
+  spinnerButtons = numberMode === "scientific" ? "never" : "onHover",
 }) => {
   const [numberText, setNumberText] = useState(
     !defaultValue ? "" : defaultValue.toString(),
@@ -153,6 +226,8 @@ const NumberInput: React.FC<NumberInputProps> = ({
       helperText={helperText}
       minValue={minValue}
       maxValue={maxValue}
+      step={step}
+      spinnerButtons={spinnerButtons}
     />
   );
 };

--- a/src/components/controls/NumberInput.tsx
+++ b/src/components/controls/NumberInput.tsx
@@ -16,6 +16,15 @@ const Modes = {
     /^[+\\-]?(([0-9]+)|([0-9]+[\\.])|([\\.][0-9]+)|([0-9]+[\\.][0-9]+))([eE][+\\-]?[0-9]+)?$/,
 };
 
+function decimalPlaces(value: number): number {
+  const text = value.toString();
+  if (text.includes("e") || text.includes("E")) {
+    return 0;
+  }
+  const pointIndex = text.indexOf(".");
+  return pointIndex === -1 ? 0 : text.length - pointIndex - 1;
+}
+
 interface NumberInputTextProps {
   label: string;
   numberMode: keyof typeof Modes;
@@ -87,7 +96,8 @@ const NumberInputText: React.FC<NumberInputTextProps> = ({
 
   const handleStep = (direction: 1 | -1) => {
     const current = isValid && numberText !== "" ? parseFloat(numberText) : 0;
-    const stepped = current + direction * step;
+    const precision = Math.max(decimalPlaces(current), decimalPlaces(step));
+    const stepped = Number((current + direction * step).toFixed(precision));
     const clamped = Math.min(maxValue, Math.max(minValue, stepped));
     setNumberText(clamped.toString());
   };


### PR DESCRIPTION
Adds a vertical up/down ButtonGroup and a step prop to `NumberInput` so values can be nudged without typing. Visibility is configurable via spinnerButtons ("always" | "onHover" | "never"), defaulting to on-hover for every mode except scientific.

<img width="325" height="117" alt="image" src="https://github.com/user-attachments/assets/8bd4f669-15dd-42e6-9cf2-0213e79111cd" />
